### PR TITLE
Use configured provider aliases

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -25,7 +25,9 @@ const {
   normalizeProviderBase,
   resolveModuleUrl,
   probeUrl,
-  setFallbackProviders
+  setFallbackProviders,
+  setDefaultProviderBase,
+  setProviderAliases
 } = network;
 const {
   loadTools,
@@ -67,6 +69,8 @@ async function bootstrap() {
   try {
     const config = await loadConfig();
     setFallbackProviders(config.fallbackProviders);
+    setDefaultProviderBase(config.providers && config.providers.default);
+    setProviderAliases(config.providers && config.providers.aliases);
     setCiLoggingEnabled(detectCiLogging(config));
     if (isCiLoggingEnabled()) {
       logClient("ci:enabled", {


### PR DESCRIPTION
## Summary
- initialize CDN provider aliases from config defaults instead of hardcoding unpkg URLs
- propagate provider defaults/aliases when bootstrapping so normalization stays in sync with config

## Testing
- bun test test-tooling/tests/bootstrap.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443e73ce70833186f995267aa9ea55)