### PR TITLE
Add environment-controlled proxy mode toggle

### DIFF
--- a/bootstrap/env.js
+++ b/bootstrap/env.js
@@ -1,0 +1,6 @@
+(function (global) {
+  // Placeholder script; the server may override this response to inject runtime proxy mode.
+  if (typeof global.__RWTRA_PROXY_MODE__ === "undefined") {
+    global.__RWTRA_PROXY_MODE__ = "auto";
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/bootstrap/script-list.html
+++ b/bootstrap/script-list.html
@@ -1,3 +1,4 @@
+<script src="bootstrap/env.js"></script>
 <script src="bootstrap/cdn/logging.js"></script>
 <script src="bootstrap/cdn/network.js"></script>
 <script src="bootstrap/cdn/import-map-init.js"></script>

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ const parsedPort = Number(rawPort);
 const port = Number.isNaN(parsedPort) ? 4173 : parsedPort;
 const proxyTarget = process.env.CDN_PROXY_TARGET || providers.default;
 const esmTarget = process.env.ESM_PROXY_TARGET || providers.esm;
+const proxyMode = normalizeProxyMode(process.env.RWTRA_PROXY_MODE);
 
 if (!proxyTarget) {
   throw new Error("Missing CDN proxy target (providers.default) in config.json");
@@ -26,6 +27,12 @@ const logStream = fs.createWriteStream(logPath, { flags: "a" });
 
 const app = express();
 app.use(express.json({ limit: "1mb" }));
+
+function normalizeProxyMode(value) {
+  if (!value) return "auto";
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === "proxy" || normalized === "direct" ? normalized : "auto";
+}
 
 function logLine(prefix, message) {
   const line = `[${new Date().toISOString()}] ${prefix} ${message}`;
@@ -56,6 +63,21 @@ app.use((req, _res, next) => {
     logLine("static", `${req.method} ${req.originalUrl} -> ${_res.statusCode} (${ms}ms)`);
   });
   next();
+});
+
+app.get("/bootstrap/env.js", (_req, res) => {
+  res.type("application/javascript");
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate");
+  const modeBody =
+    proxyMode === "auto"
+      ? "global.__RWTRA_PROXY_MODE__ = \"auto\";"
+      : `global.__RWTRA_PROXY_MODE__ = ${JSON.stringify(proxyMode)};`;
+  const body =
+    "// Generated at request time\n" +
+    "(function(global){" +
+    modeBody +
+    "})(typeof globalThis !== \"undefined\" ? globalThis : this);";
+  res.send(body);
 });
 
 app.use(
@@ -131,6 +153,10 @@ server.listen(port, host, () => {
   logLine("server", `Serving ${rootDir} on http://${host}:${port}`);
   logLine("server", `Proxying /proxy/unpkg/* -> ${proxyTarget}`);
   logLine("server", `Proxying ESM paths to ${esmTarget}`);
+  logLine(
+    "server",
+    `Proxy mode: ${proxyMode === "auto" ? "auto (host-detected)" : proxyMode}`
+  );
 });
 
 process.on("exit", () => {

--- a/test-tooling/tests/proxy-mode.test.ts
+++ b/test-tooling/tests/proxy-mode.test.ts
@@ -1,0 +1,46 @@
+// @ts-expect-error - CDN helpers are plain JS without type declarations
+import { resolveProvider } from "../../bootstrap/cdn/network.js";
+
+describe("proxy mode overrides", () => {
+  const originalEnv = process.env.RWTRA_PROXY_MODE;
+  const originalGlobal = (global as any).__RWTRA_PROXY_MODE__;
+
+  afterEach(() => {
+    process.env.RWTRA_PROXY_MODE = originalEnv;
+    (global as any).__RWTRA_PROXY_MODE__ = originalGlobal;
+  });
+
+  it("forces ci providers when proxy mode is set to proxy", () => {
+    process.env.RWTRA_PROXY_MODE = "proxy";
+    expect(
+      resolveProvider({
+        ci_provider: "/proxy/unpkg/",
+        production_provider: "https://unpkg.com/"
+      })
+    ).toBe("/proxy/unpkg/");
+  });
+
+  it("forces production providers when proxy mode is direct", () => {
+    process.env.RWTRA_PROXY_MODE = "direct";
+    (global as any).__RWTRA_PROXY_MODE__ = undefined;
+
+    expect(
+      resolveProvider({
+        ci_provider: "/proxy/unpkg/",
+        production_provider: "https://unpkg.com/"
+      })
+    ).toBe("https://unpkg.com/");
+  });
+
+  it("prefers global override over environment variables", () => {
+    process.env.RWTRA_PROXY_MODE = "proxy";
+    (global as any).__RWTRA_PROXY_MODE__ = "direct";
+
+    expect(
+      resolveProvider({
+        ci_provider: "/proxy/unpkg/",
+        production_provider: "https://unpkg.com/"
+      })
+    ).toBe("https://unpkg.com/");
+  });
+});


### PR DESCRIPTION
## Summary
- add RWTRA_PROXY_MODE support, injecting proxy mode to the client via bootstrap/env.js
- update CDN provider selection to honor proxy/direct/auto modes
- cover proxy mode behavior with new Jest tests

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bc45ca388331a2f18be4209ac16a)