### PR TITLE
Refactor interfaces into dedicated files

### DIFF
--- a/codegen/src/core/codegen/base-codegen.ts
+++ b/codegen/src/core/codegen/base-codegen.ts
@@ -17,68 +17,10 @@ import type {
   IRegistry,
   ISpec,
 } from './interfaces/index';
-
-/**
- *
- */
-interface PluginInfo {
-  id: string;
-  name: string | undefined;
-  version: string | undefined;
-  entry_point: string;
-  path: string;
-  category: string;
-  [key: string]: unknown;
-}
-
-/**
- *
- */
-interface ExecutionResults {
-  success: boolean;
-  generated: string[];
-  errors: string[];
-  warnings: string[];
-  timestamp: string;
-  stats: {
-    pluginsExecuted: number;
-    specsProcessed: number;
-    filesGenerated: number;
-    [key: string]: number;
-  };
-}
-
-/**
- *
- */
-interface AggregateResults {
-  generated: string[];
-  errors: string[];
-  warnings: string[];
-  stats: {
-    pluginsExecuted: number;
-    specsProcessed: number;
-    filesGenerated: number;
-    [key: string]: number;
-  };
-}
-
-/**
- *
- */
-interface SystemStatus {
-  initialized: boolean;
-  plugins: {
-    discovered: number;
-    loaded: number;
-  };
-  registries: {
-    plugins: number;
-    aggregates: number;
-    specs: number;
-  };
-  options: IBaseCodegenOptions;
-}
+import type { AggregateResults } from './types/aggregate-results';
+import type { ExecutionResults } from './types/execution-results';
+import type { PluginInfo } from './types/plugin-info';
+import type { SystemStatus } from './types/system-status';
 
 /**
  *

--- a/codegen/src/core/codegen/types/aggregate-results.ts
+++ b/codegen/src/core/codegen/types/aggregate-results.ts
@@ -1,0 +1,14 @@
+/**
+ * Merged results produced by aggregate execution
+ */
+export interface AggregateResults {
+  generated: string[];
+  errors: string[];
+  warnings: string[];
+  stats: {
+    pluginsExecuted: number;
+    specsProcessed: number;
+    filesGenerated: number;
+    [key: string]: number;
+  };
+}

--- a/codegen/src/core/codegen/types/execution-results.ts
+++ b/codegen/src/core/codegen/types/execution-results.ts
@@ -1,0 +1,16 @@
+/**
+ * Aggregated results from executing code generation
+ */
+export interface ExecutionResults {
+  success: boolean;
+  generated: string[];
+  errors: string[];
+  warnings: string[];
+  timestamp: string;
+  stats: {
+    pluginsExecuted: number;
+    specsProcessed: number;
+    filesGenerated: number;
+    [key: string]: number;
+  };
+}

--- a/codegen/src/core/codegen/types/plugin-info.ts
+++ b/codegen/src/core/codegen/types/plugin-info.ts
@@ -1,0 +1,12 @@
+/**
+ * Metadata collected for discovered plugins
+ */
+export interface PluginInfo {
+  id: string;
+  name: string | undefined;
+  version: string | undefined;
+  entry_point: string;
+  path: string;
+  category: string;
+  [key: string]: unknown;
+}

--- a/codegen/src/core/codegen/types/system-status.ts
+++ b/codegen/src/core/codegen/types/system-status.ts
@@ -1,0 +1,18 @@
+import type { IBaseCodegenOptions } from '../interfaces/index';
+
+/**
+ * Runtime status snapshot for the core codegen system
+ */
+export interface SystemStatus {
+  initialized: boolean;
+  plugins: {
+    discovered: number;
+    loaded: number;
+  };
+  registries: {
+    plugins: number;
+    aggregates: number;
+    specs: number;
+  };
+  options: IBaseCodegenOptions;
+}

--- a/codegen/src/core/plugins/plugin-dependency-linter.ts
+++ b/codegen/src/core/plugins/plugin-dependency-linter.ts
@@ -8,28 +8,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-
-/**
- *
- */
-interface PluginManifest {
-  id: string;
-  name?: string;
-  version?: string;
-  entry_point: string;
-  dependencies?: string[] | { core?: string; plugins?: string[] };
-  [key: string]: unknown;
-}
-
-/**
- *
- */
-interface PluginDependency {
-  pluginId: string;
-  manifest: PluginManifest;
-  entryPath: string;
-  dependencies: string[];
-}
+import type { PluginDependency } from './types/plugin-dependency';
+import type { PluginManifest } from './types/plugin-manifest';
 
 /**
  *

--- a/codegen/src/core/plugins/types/plugin-dependency.ts
+++ b/codegen/src/core/plugins/types/plugin-dependency.ts
@@ -1,0 +1,11 @@
+import type { PluginManifest } from './plugin-manifest';
+
+/**
+ * Resolved plugin dependency record
+ */
+export interface PluginDependency {
+  pluginId: string;
+  manifest: PluginManifest;
+  entryPath: string;
+  dependencies: string[];
+}

--- a/codegen/src/core/plugins/types/plugin-manifest.ts
+++ b/codegen/src/core/plugins/types/plugin-manifest.ts
@@ -1,0 +1,11 @@
+/**
+ * Shape of a plugin manifest file
+ */
+export interface PluginManifest {
+  id: string;
+  name?: string;
+  version?: string;
+  entry_point: string;
+  dependencies?: string[] | { core?: string; plugins?: string[] };
+  [key: string]: unknown;
+}

--- a/codegen/src/entrypoints/codegen-entrypoint.ts
+++ b/codegen/src/entrypoints/codegen-entrypoint.ts
@@ -9,34 +9,8 @@
 import { BaseComponent } from '../core/codegen/base-component';
 import type { LifecycleBuilder } from '../core/types/lifecycle-builder';
 import type { CompositeLifecycle } from '../core/types/composite-lifecycle';
-
-/**
- *
- */
-interface CodegenOptions {
-  outputDir?: string;
-  verbose?: boolean;
-  strictMode?: boolean;
-  [key: string]: unknown;
-}
-
-/**
- *
- */
-interface CLIArgs {
-  spec?: string;
-  output?: string;
-  language?: string;
-  profile?: string;
-  template?: string;
-  category?: string;
-  component?: string;
-  query?: string;
-  tool?: string;
-  platform?: string;
-  packageManager?: string;
-  [key: string]: unknown;
-}
+import type { CLIArgs } from './types/cli-args';
+import type { CodegenOptions } from './types/codegen-options';
 
 /**
  * CodegenEntrypoint - Uses lifecycle builder for component orchestration

--- a/codegen/src/entrypoints/types/cli-args.ts
+++ b/codegen/src/entrypoints/types/cli-args.ts
@@ -1,0 +1,17 @@
+/**
+ * Supported CLI arguments for the codegen entrypoint
+ */
+export interface CLIArgs {
+  spec?: string;
+  output?: string;
+  language?: string;
+  profile?: string;
+  template?: string;
+  category?: string;
+  component?: string;
+  query?: string;
+  tool?: string;
+  platform?: string;
+  packageManager?: string;
+  [key: string]: unknown;
+}

--- a/codegen/src/entrypoints/types/codegen-options.ts
+++ b/codegen/src/entrypoints/types/codegen-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Optional flags controlling the codegen entrypoint
+ */
+export interface CodegenOptions {
+  outputDir?: string;
+  verbose?: boolean;
+  strictMode?: boolean;
+  [key: string]: unknown;
+}

--- a/codegen/src/plugins/tools/oop-principles/src/oop-principles-plugin.ts
+++ b/codegen/src/plugins/tools/oop-principles/src/oop-principles-plugin.ts
@@ -6,35 +6,9 @@
 
 import { Plugin } from '../../../core/plugin';
 import type { ISpec } from '../../../core/interfaces/ispec';
-
-/**
- *
- */
-interface AnalyzerState {
-  violations: string[];
-  analyzed: number;
-}
-
-/**
- *
- */
-interface AnalysisResults {
-  success: boolean;
-  violations: string[];
-  summary: {
-    analyzed: number;
-    compliant: number;
-    violations: number;
-  };
-}
-
-/**
- *
- */
-interface ValidationInput {
-  operation: string;
-  [key: string]: unknown;
-}
+import type { AnalysisResults } from './types/analysis-results';
+import type { AnalyzerState } from './types/analyzer-state';
+import type { ValidationInput } from './types/validation-input';
 
 /**
  *

--- a/codegen/src/plugins/tools/oop-principles/src/types/analysis-results.ts
+++ b/codegen/src/plugins/tools/oop-principles/src/types/analysis-results.ts
@@ -1,0 +1,12 @@
+/**
+ * Results returned after analyzing OOP principles
+ */
+export interface AnalysisResults {
+  success: boolean;
+  violations: string[];
+  summary: {
+    analyzed: number;
+    compliant: number;
+    violations: number;
+  };
+}

--- a/codegen/src/plugins/tools/oop-principles/src/types/analyzer-state.ts
+++ b/codegen/src/plugins/tools/oop-principles/src/types/analyzer-state.ts
@@ -1,0 +1,7 @@
+/**
+ * Tracks analyzer state for OOP principle checks
+ */
+export interface AnalyzerState {
+  violations: string[];
+  analyzed: number;
+}

--- a/codegen/src/plugins/tools/oop-principles/src/types/validation-input.ts
+++ b/codegen/src/plugins/tools/oop-principles/src/types/validation-input.ts
@@ -1,0 +1,7 @@
+/**
+ * Allowed validation input shape for OOP principles plugin
+ */
+export interface ValidationInput {
+  operation: string;
+  [key: string]: unknown;
+}

--- a/codegen/src/plugins/tools/test-runner/src/test-runner-plugin.ts
+++ b/codegen/src/plugins/tools/test-runner/src/test-runner-plugin.ts
@@ -6,46 +6,10 @@
 
 import { Plugin } from '../../../core/plugin';
 import type { ISpec } from '../../../core/interfaces/ispec';
-
-/**
- *
- */
-interface ExecutorState {
-  framework: string;
-  testsRun: number;
-}
-
-/**
- *
- */
-interface TestResults {
-  success: boolean;
-  framework: string;
-  summary: {
-    total: number;
-    passed: number;
-    failed: number;
-  };
-}
-
-/**
- *
- */
-interface ExecutionResults {
-  summary: {
-    total: number;
-    passed: number;
-    failed: number;
-  };
-}
-
-/**
- *
- */
-interface ValidationInput {
-  operation: string;
-  [key: string]: unknown;
-}
+import type { ExecutionResults } from './types/execution-results';
+import type { ExecutorState } from './types/executor-state';
+import type { TestResults } from './types/test-results';
+import type { ValidationInput } from './types/validation-input';
 
 /**
  *

--- a/codegen/src/plugins/tools/test-runner/src/types/execution-results.ts
+++ b/codegen/src/plugins/tools/test-runner/src/types/execution-results.ts
@@ -1,0 +1,10 @@
+/**
+ * Summary results from executing the test suite
+ */
+export interface ExecutionResults {
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+}

--- a/codegen/src/plugins/tools/test-runner/src/types/executor-state.ts
+++ b/codegen/src/plugins/tools/test-runner/src/types/executor-state.ts
@@ -1,0 +1,7 @@
+/**
+ * Executor state tracking for test execution
+ */
+export interface ExecutorState {
+  framework: string;
+  testsRun: number;
+}

--- a/codegen/src/plugins/tools/test-runner/src/types/test-results.ts
+++ b/codegen/src/plugins/tools/test-runner/src/types/test-results.ts
@@ -1,0 +1,12 @@
+/**
+ * Test execution results
+ */
+export interface TestResults {
+  success: boolean;
+  framework: string;
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+}

--- a/codegen/src/plugins/tools/test-runner/src/types/validation-input.ts
+++ b/codegen/src/plugins/tools/test-runner/src/types/validation-input.ts
@@ -1,0 +1,7 @@
+/**
+ * Allowed validation input shape for the test runner plugin
+ */
+export interface ValidationInput {
+  operation: string;
+  [key: string]: unknown;
+}

--- a/codegen/src/specs/bootstrap-system/generator.ts
+++ b/codegen/src/specs/bootstrap-system/generator.ts
@@ -7,68 +7,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { BaseComponent } from '../../core/base-component';
-import type { ISpec } from '../../core/interfaces/ispec';
-
-/**
- *
- */
-interface GeneratorSpec extends ISpec {
-  specsPath?: string;
-  outputPath?: string;
-}
-
-/**
- *
- */
-interface GeneratedFile {
-  file: string;
-  type: string;
-  name: string;
-}
-
-/**
- *
- */
-interface ModuleSpec {
-  search: {
-    title: string;
-    summary: string;
-    capabilities?: string[];
-  };
-  implementation: {
-    methods: string[];
-  };
-  dependencies?: string[];
-}
-
-/**
- *
- */
-interface InterfaceSpec {
-  methods: string[];
-}
-
-/**
- *
- */
-interface SpecsData {
-  modules: Record<string, ModuleSpec>;
-  interfaces: Record<string, InterfaceSpec>;
-  search: {
-    title: string;
-    summary: string;
-    capabilities?: string[];
-  };
-}
-
-/**
- *
- */
-interface ExecutionResult {
-  success: boolean;
-  generated: GeneratedFile[];
-  specs: SpecsData;
-}
+import type { ExecutionResult } from './types/execution-result';
+import type { GeneratedFile } from './types/generated-file';
+import type { GeneratorSpec } from './types/generator-spec';
+import type { InterfaceSpec } from './types/interface-spec';
+import type { ModuleSpec } from './types/module-spec';
+import type { SpecsData } from './types/specs-data';
 
 /**
  *

--- a/codegen/src/specs/bootstrap-system/types/execution-result.ts
+++ b/codegen/src/specs/bootstrap-system/types/execution-result.ts
@@ -1,0 +1,11 @@
+import type { GeneratedFile } from './generated-file';
+import type { SpecsData } from './specs-data';
+
+/**
+ * Execution response returned by the bootstrap generator
+ */
+export interface ExecutionResult {
+  success: boolean;
+  generated: GeneratedFile[];
+  specs: SpecsData;
+}

--- a/codegen/src/specs/bootstrap-system/types/generated-file.ts
+++ b/codegen/src/specs/bootstrap-system/types/generated-file.ts
@@ -1,0 +1,8 @@
+/**
+ * Metadata describing a file created during generation
+ */
+export interface GeneratedFile {
+  file: string;
+  type: string;
+  name: string;
+}

--- a/codegen/src/specs/bootstrap-system/types/generator-spec.ts
+++ b/codegen/src/specs/bootstrap-system/types/generator-spec.ts
@@ -1,0 +1,9 @@
+import type { ISpec } from '../../core/interfaces/ispec';
+
+/**
+ * Specification contract for the bootstrap generator
+ */
+export interface GeneratorSpec extends ISpec {
+  specsPath?: string;
+  outputPath?: string;
+}

--- a/codegen/src/specs/bootstrap-system/types/interface-spec.ts
+++ b/codegen/src/specs/bootstrap-system/types/interface-spec.ts
@@ -1,0 +1,6 @@
+/**
+ * Interface specification used when generating interface stubs
+ */
+export interface InterfaceSpec {
+  methods: string[];
+}

--- a/codegen/src/specs/bootstrap-system/types/module-spec.ts
+++ b/codegen/src/specs/bootstrap-system/types/module-spec.ts
@@ -1,0 +1,14 @@
+/**
+ * Module specification used to generate bootstrap modules
+ */
+export interface ModuleSpec {
+  search: {
+    title: string;
+    summary: string;
+    capabilities?: string[];
+  };
+  implementation: {
+    methods: string[];
+  };
+  dependencies?: string[];
+}

--- a/codegen/src/specs/bootstrap-system/types/specs-data.ts
+++ b/codegen/src/specs/bootstrap-system/types/specs-data.ts
@@ -1,0 +1,15 @@
+import type { InterfaceSpec } from './interface-spec';
+import type { ModuleSpec } from './module-spec';
+
+/**
+ * Parsed spec.json representation for bootstrap generation
+ */
+export interface SpecsData {
+  modules: Record<string, ModuleSpec>;
+  interfaces: Record<string, InterfaceSpec>;
+  search: {
+    title: string;
+    summary: string;
+    capabilities?: string[];
+  };
+}

--- a/codegen/src/specs/cli/generator.ts
+++ b/codegen/src/specs/cli/generator.ts
@@ -7,63 +7,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ISpec } from '../../core/interfaces';
-
-/**
- *
- */
-interface CLIGeneratorSpec extends ISpec {
-  specsPath?: string;
-  outputPath?: string;
-}
-
-/**
- *
- */
-interface GeneratedFile {
-  file: string;
-  type: string;
-  name: string;
-}
-
-/**
- *
- */
-interface CommandSpec {
-  id: string;
-  search: {
-    title: string;
-    summary: string;
-  };
-  syntax?: string;
-  examples?: string[];
-  subcommands?: Record<
-    string,
-    {
-      syntax: string;
-      examples: string[];
-    }
-  >;
-}
-
-/**
- *
- */
-interface CLISpecData {
-  commands: Record<string, CommandSpec>;
-  search: {
-    title: string;
-    summary: string;
-  };
-}
-
-/**
- *
- */
-interface ExecutionResult {
-  success: boolean;
-  generated: GeneratedFile[];
-  specs: CLISpecData;
-}
+import type { CLIGeneratorSpec } from './types/cli-generator-spec';
+import type { CLISpecData } from './types/cli-spec-data';
+import type { CommandSpec } from './types/command-spec';
+import type { ExecutionResult } from './types/execution-result';
+import type { GeneratedFile } from './types/generated-file';
 
 /**
  *

--- a/codegen/src/specs/cli/types/cli-generator-spec.ts
+++ b/codegen/src/specs/cli/types/cli-generator-spec.ts
@@ -1,0 +1,9 @@
+import type { ISpec } from '../../core/interfaces';
+
+/**
+ * Specification contract for the CLI generator
+ */
+export interface CLIGeneratorSpec extends ISpec {
+  specsPath?: string;
+  outputPath?: string;
+}

--- a/codegen/src/specs/cli/types/cli-spec-data.ts
+++ b/codegen/src/specs/cli/types/cli-spec-data.ts
@@ -1,0 +1,12 @@
+import type { CommandSpec } from './command-spec';
+
+/**
+ * Parsed CLI specification content
+ */
+export interface CLISpecData {
+  commands: Record<string, CommandSpec>;
+  search: {
+    title: string;
+    summary: string;
+  };
+}

--- a/codegen/src/specs/cli/types/command-spec.ts
+++ b/codegen/src/specs/cli/types/command-spec.ts
@@ -1,0 +1,19 @@
+/**
+ * Specification for a single CLI command
+ */
+export interface CommandSpec {
+  id: string;
+  search: {
+    title: string;
+    summary: string;
+  };
+  syntax?: string;
+  examples?: string[];
+  subcommands?: Record<
+    string,
+    {
+      syntax: string;
+      examples: string[];
+    }
+  >;
+}

--- a/codegen/src/specs/cli/types/execution-result.ts
+++ b/codegen/src/specs/cli/types/execution-result.ts
@@ -1,0 +1,11 @@
+import type { GeneratedFile } from './generated-file';
+import type { CLISpecData } from './cli-spec-data';
+
+/**
+ * Execution response for the CLI generator
+ */
+export interface ExecutionResult {
+  success: boolean;
+  generated: GeneratedFile[];
+  specs: CLISpecData;
+}

--- a/codegen/src/specs/cli/types/generated-file.ts
+++ b/codegen/src/specs/cli/types/generated-file.ts
@@ -1,0 +1,8 @@
+/**
+ * Metadata describing a CLI file produced by the generator
+ */
+export interface GeneratedFile {
+  file: string;
+  type: string;
+  name: string;
+}

--- a/codegen/src/specs/webui/generator.ts
+++ b/codegen/src/specs/webui/generator.ts
@@ -7,82 +7,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ISpec } from '../../core/interfaces';
-
-/**
- *
- */
-interface WebUIGeneratorSpec extends ISpec {
-  specsPath?: string;
-  outputPath?: string;
-}
-
-/**
- *
- */
-interface GeneratedFile {
-  file: string;
-  type: string;
-  name: string;
-}
-
-/**
- *
- */
-interface ComponentSpec {
-  id: string;
-  search: {
-    title: string;
-    summary: string;
-  };
-  features?: string[];
-  capabilities?: string[];
-  searchFields?: string[];
-  filters?: {
-    name: string;
-    values: string[];
-  }[];
-}
-
-/**
- *
- */
-interface PageSpec {
-  id: string;
-  route: string;
-  components: string[];
-}
-
-/**
- *
- */
-interface APIRouteSpec {
-  id: string;
-  route: string;
-  method: string;
-  description: string;
-}
-
-/**
- *
- */
-interface WebUISpecData {
-  components: Record<string, ComponentSpec>;
-  pages: Record<string, PageSpec>;
-  'api-routes': Record<string, APIRouteSpec>;
-  search: {
-    title: string;
-    summary: string;
-  };
-}
-
-/**
- *
- */
-interface ExecutionResult {
-  success: boolean;
-  generated: GeneratedFile[];
-  specs: WebUISpecData;
-}
+import type { APIRouteSpec } from './types/api-route-spec';
+import type { ComponentSpec } from './types/component-spec';
+import type { ExecutionResult } from './types/execution-result';
+import type { GeneratedFile } from './types/generated-file';
+import type { PageSpec } from './types/page-spec';
+import type { WebUIGeneratorSpec } from './types/webui-generator-spec';
+import type { WebUISpecData } from './types/webui-spec-data';
 
 /**
  *

--- a/codegen/src/specs/webui/types/api-route-spec.ts
+++ b/codegen/src/specs/webui/types/api-route-spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Specification for a generated API route
+ */
+export interface APIRouteSpec {
+  id: string;
+  route: string;
+  method: string;
+  description: string;
+}

--- a/codegen/src/specs/webui/types/component-spec.ts
+++ b/codegen/src/specs/webui/types/component-spec.ts
@@ -1,0 +1,17 @@
+/**
+ * Specification for a generated Web UI component
+ */
+export interface ComponentSpec {
+  id: string;
+  search: {
+    title: string;
+    summary: string;
+  };
+  features?: string[];
+  capabilities?: string[];
+  searchFields?: string[];
+  filters?: {
+    name: string;
+    values: string[];
+  }[];
+}

--- a/codegen/src/specs/webui/types/execution-result.ts
+++ b/codegen/src/specs/webui/types/execution-result.ts
@@ -1,0 +1,11 @@
+import type { GeneratedFile } from './generated-file';
+import type { WebUISpecData } from './webui-spec-data';
+
+/**
+ * Execution response for Web UI generator
+ */
+export interface ExecutionResult {
+  success: boolean;
+  generated: GeneratedFile[];
+  specs: WebUISpecData;
+}

--- a/codegen/src/specs/webui/types/generated-file.ts
+++ b/codegen/src/specs/webui/types/generated-file.ts
@@ -1,0 +1,8 @@
+/**
+ * Metadata describing a generated Web UI file
+ */
+export interface GeneratedFile {
+  file: string;
+  type: string;
+  name: string;
+}

--- a/codegen/src/specs/webui/types/page-spec.ts
+++ b/codegen/src/specs/webui/types/page-spec.ts
@@ -1,0 +1,8 @@
+/**
+ * Specification describing a generated page
+ */
+export interface PageSpec {
+  id: string;
+  route: string;
+  components: string[];
+}

--- a/codegen/src/specs/webui/types/webui-generator-spec.ts
+++ b/codegen/src/specs/webui/types/webui-generator-spec.ts
@@ -1,0 +1,9 @@
+import type { ISpec } from '../../core/interfaces';
+
+/**
+ * Specification contract for the Web UI generator
+ */
+export interface WebUIGeneratorSpec extends ISpec {
+  specsPath?: string;
+  outputPath?: string;
+}

--- a/codegen/src/specs/webui/types/webui-spec-data.ts
+++ b/codegen/src/specs/webui/types/webui-spec-data.ts
@@ -1,0 +1,16 @@
+import type { APIRouteSpec } from './api-route-spec';
+import type { ComponentSpec } from './component-spec';
+import type { PageSpec } from './page-spec';
+
+/**
+ * Parsed spec.json representation for Web UI generation
+ */
+export interface WebUISpecData {
+  components: Record<string, ComponentSpec>;
+  pages: Record<string, PageSpec>;
+  'api-routes': Record<string, APIRouteSpec>;
+  search: {
+    title: string;
+    summary: string;
+  };
+}


### PR DESCRIPTION
## Summary
- move inline interface definitions into dedicated type files across core codegen classes and plugins
- update CLI, WebUI, and bootstrap generators to import the new single-interface modules
- add explicit types for plugin utilities and entrypoint options to keep interfaces isolated per file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad7c6b38083318328992e19f8475c)