### PR TITLE
Add comprehensive documentation for React doc viewer

### DIFF
--- a/docs-viewer/README.md
+++ b/docs-viewer/README.md
@@ -1,36 +1,59 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# React Doc Viewer
 
-## Getting Started
+A Next.js + Material UI reader for the platform's markdown documentation. The app renders content from `public/docs`, organizes it with a navigation tree, and applies consistent theming so the docs feel like part of the product.
 
-First, run the development server:
+## Quick start
 
 ```bash
+cd docs-viewer
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+- Visit `http://localhost:3000` to browse the docs.
+- Build for production with `npm run build` and `npm run start`.
+- Lint the code with `npm run lint`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## How the viewer is structured
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Area | Purpose |
+| --- | --- |
+| `src/app` | Next.js app router entry point, layout, and global styles. The home page wires navigation, state, and markdown loading. |
+| `src/components` | UI primitives: navigation tree, markdown renderer, and Material UI provider wrapper. |
+| `src/lib` | Documentation catalogue (`DOCS_STRUCTURE`) plus helpers to look up sections and files. |
+| `src/types` | Shared TypeScript interfaces for doc sections/files. |
+| `public/docs` | The source markdown files that get fetched and rendered. |
+| `scripts` | Utility scripts (if present) for local workflows. |
 
-## Learn More
+## Data model and content pipeline
 
-To learn more about Next.js, take a look at the following resources:
+1. **Catalogue definition** — `DOCS_STRUCTURE` lists every section and file with stable IDs and paths inside `public/docs`. The helper functions expose that structure for lookups and UI rendering.【F:docs-viewer/src/lib/docs-structure-data.ts†L1-L78】【F:docs-viewer/src/lib/docs-structure.ts†L1-L3】
+2. **Lookup helpers** — `getDocFile`, `getSection`, and `getAllDocFiles` wrap the catalogue for consumers. The helpers shield the UI from needing to walk arrays directly.【F:docs-viewer/src/lib/get-doc-file.ts†L1-L14】【F:docs-viewer/src/lib/get-section.ts†L1-L9】【F:docs-viewer/src/lib/get-all-doc-files.ts†L1-L9】
+3. **Markdown source** — Each markdown file lives under `public/docs/<section>/<file>.md`. Those files are fetched at runtime via the browser `fetch` API and rendered as markdown content.
+4. **Type safety** — The catalogue and helpers rely on the `DocSection` and `DocFile` interfaces so TypeScript can validate that IDs, titles, and paths are present.【F:docs-viewer/src/types/doc-section.ts†L1-L11】【F:docs-viewer/src/types/doc-file.ts†L1-L8】
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## UI flow
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+1. **Navigation** — `DocsNavigation` reads `DOCS_STRUCTURE` to build a collapsible list grouped by section. It highlights the active document and notifies the parent when a user picks another file.【F:docs-viewer/src/components/docs-navigation.tsx†L15-L75】
+2. **Page state** — The home page (`src/app/page.tsx`) tracks the active section/file, fetches markdown when they change, and handles loading/error UI. The first section/file is selected by default so content appears immediately.【F:docs-viewer/src/app/page.tsx†L1-L86】
+3. **Rendering** — `MarkdownViewer` wraps `react-markdown` inside a styled Material UI `Paper` element. It tunes typography, code blocks, blockquotes, and tables to keep docs readable.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L88】
+4. **Theming** — `Providers` configures a light Material UI theme with project fonts and baseline styles, keeping the viewer visually consistent.【F:docs-viewer/src/components/providers.tsx†L1-L27】
 
-## Deploy on Vercel
+## Adding or updating documentation
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+1. Create or edit markdown files inside `public/docs/<section>/...`. Keep filenames in sync with the `path` values in `DOCS_STRUCTURE`.
+2. Register the file in `DOCS_STRUCTURE` with a stable `id`, human-friendly `title`, and `path` relative to `/public/docs`. Group related files under a single section entry for tidy navigation.
+3. Restart or refresh the dev server. The nav tree and content loader will pick up the new file immediately.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Styling notes
+
+- Global typography comes from the Material UI theme in `src/components/providers.tsx` and extra rules in `globals.css`.
+- Markdown styles (headings, code blocks, blockquotes, tables) live inside `MarkdownViewer` so new elements can be added in one place.
+- Navigation uses Material UI list components, giving keyboard and focus styles out of the box.
+
+## Troubleshooting
+
+- **Document not found**: Ensure the `path` in `DOCS_STRUCTURE` matches the file location under `public/docs`.
+- **Blank page after selection**: Check browser devtools for fetch errors—missing files or 404s will surface here.
+- **Styling regressions**: Look for overrides in `globals.css` or the `MarkdownViewer` component that may be clashing with Material UI defaults.
+

--- a/docs-viewer/public/docs/README.md
+++ b/docs-viewer/public/docs/README.md
@@ -1,3 +1,22 @@
 # docs-viewer/public/docs
 
-This directory contains files for the `docs-viewer/public/docs` component of the project.
+This directory is the content source for the React Doc Viewer. Everything under here is served statically by Next.js and fetched by the client at `/docs/<section>/<file>.md`.
+
+## Structure
+
+- Top-level folders (`architecture`, `concepts`, `interfaces`, `systems`) map to sections defined in `src/lib/docs-structure-data.ts`.
+- Each markdown file inside a folder represents one document entry in a section's `files` array.
+- Section-level `README.md` files can provide overviews but are not automatically linked unless you add them to `DOCS_STRUCTURE`.
+
+## Adding content
+
+1. Create the markdown file under the correct section folder.
+2. Update `DOCS_STRUCTURE` so the viewer can link to it and display the right title/path.
+3. Keep filenames lowercase-with-dashes to stay consistent with existing entries.
+
+## Authoring tips
+
+- Use standard markdown headings; the viewer styles `h1`–`h4`, lists, code fences, tables, and blockquotes for readability.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L88】
+- Favor shorter sections with descriptive headings so the navigation tree remains scannable.
+- If you need code highlighting nuances, wrap snippets in triple backticks; inline code is also supported.
+

--- a/docs-viewer/src/README.md
+++ b/docs-viewer/src/README.md
@@ -1,3 +1,22 @@
 # docs-viewer/src
 
-This directory contains files for the `docs-viewer/src` component of the project.
+This directory holds the application source code for the React Doc Viewer. The key areas are:
+
+- `app/` — Next.js app router entry point, layout, global styles, and the home page that fetches markdown files and renders them.
+- `components/` — Reusable UI pieces such as the navigation tree, markdown renderer, and Material UI provider wrapper.
+- `lib/` — Documentation catalogue (`DOCS_STRUCTURE`) plus helper functions for looking up sections and files.
+- `types/` — TypeScript interfaces that describe doc sections, files, and the full content tree.
+
+### Runtime flow
+
+1. The home page (`app/page.tsx`) keeps track of the selected section/file, fetches the markdown from `public/docs`, and handles loading/error UI.【F:docs-viewer/src/app/page.tsx†L1-L86】
+2. `components/docs-navigation.tsx` reads the catalogue to build a collapsible section/file list and notifies the page when the user picks a new document.【F:docs-viewer/src/components/docs-navigation.tsx†L15-L75】
+3. `components/markdown-viewer.tsx` styles and renders the markdown content with `react-markdown` and Material UI typography.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L88】
+4. Theme defaults (colors, fonts, baselines) are set in `components/providers.tsx` so every page uses the same Material UI theme.【F:docs-viewer/src/components/providers.tsx†L1-L27】
+
+### Working with the catalogue
+
+- The canonical list of sections/files lives in `lib/docs-structure-data.ts`. Update it when adding docs so navigation and fetches stay in sync.【F:docs-viewer/src/lib/docs-structure-data.ts†L1-L78】
+- Helper functions in `lib/get-doc-file.ts`, `lib/get-section.ts`, and `lib/get-all-doc-files.ts` centralize lookups and can be reused by new routes or components.【F:docs-viewer/src/lib/get-doc-file.ts†L1-L14】【F:docs-viewer/src/lib/get-section.ts†L1-L9】【F:docs-viewer/src/lib/get-all-doc-files.ts†L1-L9】
+- Types in `types/doc-file.ts` and `types/doc-section.ts` keep the catalogue strongly typed to prevent mismatched IDs or paths.【F:docs-viewer/src/types/doc-file.ts†L1-L8】【F:docs-viewer/src/types/doc-section.ts†L1-L11】
+

--- a/docs-viewer/src/app/README.md
+++ b/docs-viewer/src/app/README.md
@@ -1,3 +1,9 @@
 # docs-viewer/src/app
 
-This directory contains files for the `docs-viewer/src/app` component of the project.
+Next.js app router entry point for the React Doc Viewer.
+
+- **page.tsx** — Client-side page that manages selected section/file state, fetches markdown from `/docs`, and renders it through the markdown viewer with loading/error feedback.【F:docs-viewer/src/app/page.tsx†L1-L86】
+- **layout.tsx** — Defines the root HTML scaffolding, imports the Geist font, and wraps pages with `Providers` so Material UI theming is available everywhere.【F:docs-viewer/src/app/layout.tsx†L1-L44】
+- **globals.css** — Tailors base styles (font families, list resets, layout helpers) to match the viewer's typography.【F:docs-viewer/src/app/globals.css†L1-L86】
+- **favicon.ico** — App icon served from the Next.js public assets pipeline.
+

--- a/docs-viewer/src/components/README.md
+++ b/docs-viewer/src/components/README.md
@@ -1,3 +1,10 @@
 # docs-viewer/src/components
 
-This directory contains files for the `docs-viewer/src/components` component of the project.
+UI building blocks for the React Doc Viewer.
+
+- **providers.tsx** — Wraps pages with a Material UI theme and `CssBaseline` so the app shares fonts, colors, and resets.【F:docs-viewer/src/components/providers.tsx†L1-L27】
+- **docs-navigation.tsx** — Builds the collapsible section/file navigation from `DOCS_STRUCTURE`, tracks which sections are open, and calls `onFileSelect` when a document is chosen.【F:docs-viewer/src/components/docs-navigation.tsx†L15-L75】
+- **markdown-viewer.tsx** — Renders markdown via `react-markdown` and applies typography, spacing, and code/table styling for readable docs.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L88】
+
+These components are client-side (`"use client"`) because they rely on browser interactions (stateful navigation and fetch-driven markdown rendering).
+

--- a/docs-viewer/src/lib/README.md
+++ b/docs-viewer/src/lib/README.md
@@ -1,3 +1,10 @@
 # docs-viewer/src/lib
 
-This directory contains files for the `docs-viewer/src/lib` component of the project.
+Documentation catalogue and lookup helpers.
+
+- **docs-structure-data.ts** — The authoritative list of documentation sections and files. Update this file when adding or renaming markdown content.【F:docs-viewer/src/lib/docs-structure-data.ts†L1-L78】
+- **get-doc-file.ts** — Finds a doc entry by section and file ID so callers can resolve the correct path and metadata.【F:docs-viewer/src/lib/get-doc-file.ts†L1-L14】
+- **get-section.ts** — Returns a section entry by ID, useful for navigation and section-level UI.【F:docs-viewer/src/lib/get-section.ts†L1-L9】
+- **get-all-doc-files.ts** — Flattens the catalogue into a single list of files (handy for search or indexing).【F:docs-viewer/src/lib/get-all-doc-files.ts†L1-L9】
+- **docs-structure.ts** — Re-exports the catalogue and helpers for backward compatibility across imports.【F:docs-viewer/src/lib/docs-structure.ts†L1-L3】
+

--- a/docs-viewer/src/types/README.md
+++ b/docs-viewer/src/types/README.md
@@ -1,3 +1,9 @@
 # docs-viewer/src/types
 
-This directory contains files for the `docs-viewer/src/types` component of the project.
+Shared TypeScript contracts for the documentation catalogue.
+
+- **doc-file.ts** — Shape of an individual document entry: `id`, `title`, `path`, and owning `section`.【F:docs-viewer/src/types/doc-file.ts†L1-L8】
+- **doc-section.ts** — Represents a section that holds a list of `DocFile` entries. Used by navigation and content lookups.【F:docs-viewer/src/types/doc-section.ts†L1-L11】
+- **doc-content.ts** — Wraps the full set of sections when you need to treat the docs as one content tree.【F:docs-viewer/src/types/doc-content.ts†L1-L8】
+- **docs.ts** — Convenience re-exports of the above interfaces for legacy imports.【F:docs-viewer/src/types/docs.ts†L1-L4】
+


### PR DESCRIPTION
## Summary
- replace the default docs-viewer README with a full overview of the React Doc Viewer, its data pipeline, and UI flow
- document each source directory and component so contributors understand where navigation, theming, and markdown rendering live
- add guidance for authoring markdown content and keeping the catalogue in sync with `DOCS_STRUCTURE`

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adf753d548331a90830880bc1cf57)