### PR TITLE
Enhance WebUI API route generation

### DIFF
--- a/codegen/src/specs/webui/generator.test.ts
+++ b/codegen/src/specs/webui/generator.test.ts
@@ -1,0 +1,149 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WebUIGenerator } from './generator';
+import type { APIRouteSpec } from './types/api-route-spec';
+import type { WebUISpecData } from './types/webui-spec-data';
+
+vi.mock('next/server', () => {
+  class MockRequest {
+    url: string;
+    private body: unknown;
+
+    constructor(url: string, body?: unknown) {
+      this.url = url;
+      this.body = body;
+    }
+
+    async json() {
+      return this.body;
+    }
+  }
+
+  const NextResponse = {
+    json: (payload: unknown, init?: { status?: number }) => ({ status: init?.status ?? 200, body: payload }),
+  };
+
+  return { NextRequest: MockRequest, NextResponse };
+});
+
+function writeSpec(specsPath: string, apiSpec: APIRouteSpec) {
+  const spec: WebUISpecData = {
+    uuid: 'test',
+    id: 'webui',
+    type: 'interface',
+    components: {},
+    pages: {},
+    'api-routes': {
+      [apiSpec.id]: apiSpec,
+    },
+    search: { title: 'Web UI', summary: 'Generated for tests' },
+  } as WebUISpecData;
+
+  fs.writeFileSync(path.join(specsPath, 'spec.json'), JSON.stringify(spec, null, 2));
+}
+
+async function generateRouteModule(apiSpec: APIRouteSpec) {
+  const specsPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webui-specs-'));
+  const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'webui-output-'));
+  writeSpec(specsPath, apiSpec);
+
+  const generator = new WebUIGenerator({ uuid: 'test', id: 'webui', search: { title: 't', summary: 's' }, specsPath, outputPath });
+  await generator.initialise();
+  await generator.execute({});
+
+  const normalisedRoute = apiSpec.route.replace(/^\/+/, '');
+  const modulePath = path.join(outputPath, 'app', 'api', normalisedRoute, 'route.ts');
+  const moduleUrl = pathToFileURL(modulePath).href;
+  // eslint-disable-next-line vitest/await-expect
+  return import(moduleUrl);
+}
+
+const successResponse = {
+  status: 201,
+  schema: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      orderId: { type: 'string' },
+      name: { type: 'string' },
+      quantity: { type: 'number' },
+    },
+  },
+};
+
+const errorResponse = {
+  status: 422,
+  schema: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      errors: { type: 'array', items: { type: 'string' } },
+      message: { type: 'string' },
+    },
+  },
+};
+
+const baseApiSpec: APIRouteSpec = {
+  id: 'orders',
+  route: '/orders',
+  method: 'post',
+  description: 'Create orders',
+  params: [
+    { name: 'tenant', in: 'query', type: 'string', required: true },
+    { name: 'priority', in: 'query', type: 'boolean' },
+  ],
+  body: {
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', required: true },
+        quantity: { type: 'number', required: true },
+      },
+    },
+  },
+  responses: {
+    success: successResponse,
+    errors: [errorResponse],
+  },
+};
+
+describe('WebUIGenerator API route generation', () => {
+  it('returns structured success responses when validation passes', async () => {
+    const module = await generateRouteModule(baseApiSpec);
+    const { NextRequest } = await import('next/server');
+
+    const request = new NextRequest('https://example.com/api/orders?tenant=acme&priority=true', {
+      name: 'Widget',
+      quantity: 2,
+    });
+
+    const response = await module.POST(request);
+
+    expect(response.status).toBe(successResponse.status);
+    expect(response.body).toMatchObject({
+      success: true,
+      name: 'Widget',
+      quantity: 2,
+    });
+    expect(response.body).toHaveProperty('orderId');
+  });
+
+  it('returns schema-aligned errors when validation fails', async () => {
+    const module = await generateRouteModule(baseApiSpec);
+    const { NextRequest } = await import('next/server');
+
+    const request = new NextRequest('https://example.com/api/orders', {
+      name: 'Widget',
+    });
+
+    const response = await module.POST(request);
+
+    expect(response.status).toBe(errorResponse.status);
+    expect(response.body).toMatchObject({ success: false });
+    expect(response.body.errors?.length).toBeGreaterThan(0);
+  });
+});

--- a/codegen/src/specs/webui/generator.ts
+++ b/codegen/src/specs/webui/generator.ts
@@ -7,7 +7,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ISpec } from '../../core/interfaces';
-import type { APIRouteSpec } from './types/api-route-spec';
+import type {
+  APIRouteParam,
+  APIRouteSpec,
+  ResponseSpec,
+  SchemaDefinition,
+} from './types/api-route-spec';
 import type { ComponentSpec } from './types/component-spec';
 import type { ExecutionResult } from './types/execution-result';
 import type { GeneratedFile } from './types/generated-file';
@@ -123,7 +128,7 @@ export class WebUIGenerator {
    */
   private _generateAPIRoute(apiName: string, apiSpec: APIRouteSpec): GeneratedFile {
     const apiCode = this._generateAPICode(apiName, apiSpec),
-      filePath = path.join(this.outputPath, 'app', 'api', apiSpec.route, 'route.ts');
+      filePath = path.join(this.outputPath, 'app', 'api', this._normaliseRoute(apiSpec.route), 'route.ts');
 
     fs.writeFileSync(filePath, apiCode);
     return { file: filePath, type: 'api', name: apiName };
@@ -208,6 +213,21 @@ ${componentUsage}
    * @param apiSpec
    */
   private _generateAPICode(apiName: string, apiSpec: APIRouteSpec): string {
+    const method = apiSpec.method.toUpperCase(),
+      paramsSchema = this._buildParamsSchema(apiSpec.params),
+      requestBodySchema = apiSpec.body?.schema ?? null,
+      successResponse = apiSpec.responses?.success,
+      errorResponse = this._selectErrorResponse(apiSpec.responses?.errors),
+      successStatus = successResponse?.status ?? 200,
+      errorStatus = errorResponse?.status ?? 400,
+      stubResponse = this._buildExampleFromSchema(successResponse?.schema ?? null),
+      paramsExtractionCode = this._buildParamsExtraction(apiSpec.params ?? []),
+      paramSchemaLiteral = this._schemaToLiteral(paramsSchema),
+      requestSchemaLiteral = this._schemaToLiteral(requestBodySchema),
+      successSchemaLiteral = this._schemaToLiteral(successResponse?.schema ?? null),
+      errorSchemaLiteral = this._schemaToLiteral(errorResponse?.schema ?? null),
+      adapterName = this._buildAdapterName(apiName);
+
     return `/**
  * Generated ${apiSpec.description}
  *
@@ -218,18 +238,119 @@ ${componentUsage}
 
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function ${apiSpec.method.toUpperCase()}(request: NextRequest) {
+type SchemaDefinition = {
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array';
+  required?: boolean;
+  properties?: Record<string, SchemaDefinition>;
+  items?: SchemaDefinition;
+};
+
+const parameterSchema: SchemaDefinition | null = ${paramSchemaLiteral};
+const requestBodySchema: SchemaDefinition | null = ${requestSchemaLiteral};
+const successResponseSchema: SchemaDefinition | null = ${successSchemaLiteral};
+const errorResponseSchema: SchemaDefinition | null = ${errorSchemaLiteral};
+
+function validateSchema(value: unknown, schema: SchemaDefinition | null, path = 'value'): string[] {
+  if (!schema) return [];
+  const errors: string[] = [];
+
+  switch (schema.type) {
+    case 'object': {
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        errors.push(path + ' should be an object');
+        break;
+      }
+      const properties = schema.properties ?? {};
+      for (const [key, propertySchema] of Object.entries(properties)) {
+        const childValue = (value as Record<string, unknown>)[key];
+        if (propertySchema.required && (childValue === undefined || childValue === null)) {
+          errors.push(path + '.' + key + ' is required');
+          continue;
+        }
+        if (childValue !== undefined) {
+          errors.push(...validateSchema(childValue, propertySchema, path + '.' + key));
+        }
+      }
+      break;
+    }
+    case 'array': {
+      if (!Array.isArray(value)) {
+        errors.push(path + ' should be an array');
+        break;
+      }
+      value.forEach((item, idx) => {
+        errors.push(...validateSchema(item, schema.items ?? null, path + '[' + idx + ']'));
+      });
+      break;
+    }
+    default: {
+      const expected = schema.type;
+      if (typeof value !== expected) {
+        errors.push(path + ' should be type ' + expected);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function buildExampleFromSchema(schema: SchemaDefinition | null): unknown {
+  if (!schema) return {};
+
+  switch (schema.type) {
+    case 'string':
+      return '';
+    case 'number':
+      return 0;
+    case 'boolean':
+      return true;
+    case 'array':
+      return schema.items ? [buildExampleFromSchema(schema.items)] : [];
+    case 'object': {
+      const result: Record<string, unknown> = {};
+      for (const [key, propertySchema] of Object.entries(schema.properties ?? {})) {
+        result[key] = buildExampleFromSchema(propertySchema);
+      }
+      return result;
+    }
+    default:
+      return {};
+  }
+}
+
+async function ${adapterName}(input: { params: Record<string, unknown>; body?: unknown }) {
+  // TODO: Replace with domain-specific service adapter
+  return { ...buildExampleFromSchema(successResponseSchema), ...input.body };
+}
+
+export async function ${method}(request: NextRequest) {
   try {
-    // TODO: Implement ${apiName} API logic
-    return NextResponse.json({
-      message: '${apiSpec.description}',
-      success: true
-    });
+    ${paramsExtractionCode}
+    const body = ${requestBodySchema ? 'await request.json()' : 'undefined'};
+
+    const validationErrors = [
+      ...validateSchema(params, parameterSchema, 'params'),
+      ...validateSchema(body, requestBodySchema, 'body'),
+    ].filter(Boolean);
+
+    if (validationErrors.length) {
+      const errorPayload = buildExampleFromSchema(errorResponseSchema) as Record<string, unknown>;
+      if (errorPayload && typeof errorPayload === 'object') {
+        errorPayload.errors = validationErrors;
+        (errorPayload as { success?: boolean }).success = false;
+      }
+      return NextResponse.json(errorPayload ?? { success: false, errors: validationErrors }, { status: ${errorStatus} });
+    }
+
+    const result = await ${adapterName}({ params, body });
+    return NextResponse.json(result ?? ${JSON.stringify(stubResponse)}, { status: ${successStatus} });
   } catch (error) {
-    return NextResponse.json({
-      message: 'API Error',
-      error: (error as Error).message
-    }, { status: 500 });
+    const errorPayload = buildExampleFromSchema(errorResponseSchema) as Record<string, unknown>;
+    if (errorPayload && typeof errorPayload === 'object') {
+      (errorPayload as { success?: boolean }).success = false;
+      (errorPayload as { message?: string }).message = (error as Error).message;
+    }
+    return NextResponse.json(errorPayload ?? { success: false, message: 'API Error' }, { status: ${errorStatus} });
   }
 }`;
   }
@@ -254,7 +375,7 @@ export async function ${apiSpec.method.toUpperCase()}(request: NextRequest) {
     // Add API route directories
     for (const apiName of Object.keys(this._loadSpecs()['api-routes'])) {
       const apiSpec = this._loadSpecs()['api-routes'][apiName];
-      dirs.push(path.join(this.outputPath, 'app', 'api', apiSpec.route));
+      dirs.push(path.join(this.outputPath, 'app', 'api', this._normaliseRoute(apiSpec.route)));
     }
 
     dirs.forEach((dir) => {
@@ -276,6 +397,97 @@ export async function ${apiSpec.method.toUpperCase()}(request: NextRequest) {
       'specsPath' in input &&
       'outputPath' in input
     );
+  }
+
+  private _schemaToLiteral(schema: SchemaDefinition | null): string {
+    return JSON.stringify(schema, null, 2);
+  }
+
+  private _buildParamsSchema(params?: APIRouteParam[]): SchemaDefinition | null {
+    if (!params?.length) return null;
+
+    const properties: Record<string, SchemaDefinition> = {};
+    for (const param of params) {
+      properties[param.name] = {
+        type: param.type,
+        required: param.required,
+      };
+    }
+
+    return { type: 'object', properties };
+  }
+
+  private _buildParamsExtraction(params: APIRouteParam[]): string {
+    if (!params.length) {
+      return 'const params: Record<string, unknown> = {};';
+    }
+
+    const lines: string[] = ['const url = new URL(request.url);', 'const params: Record<string, unknown> = {'];
+
+    for (const param of params) {
+      const getter =
+        param.in === 'path'
+          ? "(url.pathname.split('/').filter(Boolean).pop() ?? '')"
+          : `url.searchParams.get('${param.name}')`;
+      const parsedValue = this._wrapTypeConversion(param.type, getter);
+
+      lines.push(`  ${param.name}: ${parsedValue},`);
+    }
+
+    lines.push('};');
+    return lines.join('\n    ');
+  }
+
+  private _wrapTypeConversion(type: ResponseSpec['schema']['type'] | undefined, expression: string): string {
+    switch (type) {
+      case 'number':
+        return `(${expression} !== null ? Number(${expression}) : undefined)`;
+      case 'boolean':
+        return `(${expression} === 'true' ? true : ${expression} === 'false' ? false : undefined)`;
+      default:
+        return expression;
+    }
+  }
+
+  private _buildExampleFromSchema(schema: SchemaDefinition | null): unknown {
+    if (!schema) return {};
+
+    switch (schema.type) {
+      case 'string':
+        return 'example';
+      case 'number':
+        return 0;
+      case 'boolean':
+        return true;
+      case 'array':
+        return schema.items ? [this._buildExampleFromSchema(schema.items)] : [];
+      case 'object': {
+        const result: Record<string, unknown> = {};
+        for (const [key, propertySchema] of Object.entries(schema.properties ?? {})) {
+          result[key] = this._buildExampleFromSchema(propertySchema);
+        }
+        return result;
+      }
+      default:
+        return {};
+    }
+  }
+
+  private _selectErrorResponse(errors?: ResponseSpec[]): ResponseSpec | null {
+    if (!errors?.length) return null;
+    return errors[0];
+  }
+
+  private _buildAdapterName(apiName: string): string {
+    const [first, ...rest] = apiName.split(/[-_]/);
+    const pascal = [first, ...rest.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))]
+      .join('')
+      .replace(/^(\w)/, (match) => match.toUpperCase());
+    return `invoke${pascal}Adapter`;
+  }
+
+  private _normaliseRoute(route: string): string {
+    return route.replace(/^\/+/, '');
   }
 }
 

--- a/codegen/src/specs/webui/spec.json
+++ b/codegen/src/specs/webui/spec.json
@@ -151,21 +151,146 @@
       "id": "webui.api.generate",
       "route": "/api/generate",
       "method": "POST",
-      "description": "Generate artifact from specs"
+      "description": "Generate artifact from specs",
+      "params": [
+        {
+          "name": "format",
+          "in": "query",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "body": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "spec": {
+              "type": "object",
+              "required": true,
+              "properties": {
+                "name": { "type": "string", "required": true },
+                "version": { "type": "string" }
+              }
+            },
+            "optimize": { "type": "boolean" }
+          }
+        }
+      },
+      "responses": {
+        "success": {
+          "status": 201,
+          "description": "Artifact generated",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "success": { "type": "boolean" },
+              "artifactId": { "type": "string" },
+              "format": { "type": "string" }
+            }
+          }
+        },
+        "errors": [
+          {
+            "status": 400,
+            "description": "Invalid request",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": { "type": "boolean" },
+                "errors": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        ]
+      }
     },
     "preview": {
       "uuid": "550e8400-e29b-41d4-a716-446655440029",
       "id": "webui.api.preview",
       "route": "/api/preview",
       "method": "POST",
-      "description": "Generate preview of code output"
+      "description": "Generate preview of code output",
+      "body": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "snippet": { "type": "string", "required": true },
+            "language": { "type": "string", "required": true }
+          }
+        }
+      },
+      "responses": {
+        "success": {
+          "status": 200,
+          "description": "Preview generated",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "success": { "type": "boolean" },
+              "preview": { "type": "string" }
+            }
+          }
+        },
+        "errors": [
+          {
+            "status": 422,
+            "description": "Preview generation failed",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": { "type": "boolean" },
+                "message": { "type": "string" }
+              }
+            }
+          }
+        ]
+      }
     },
     "search": {
       "uuid": "550e8400-e29b-41d4-a716-446655440030",
       "id": "webui.api.search",
       "route": "/api/search",
       "method": "GET",
-      "description": "Search components by query and filters"
+      "description": "Search components by query and filters",
+      "params": [
+        { "name": "q", "in": "query", "type": "string", "required": true },
+        { "name": "limit", "in": "query", "type": "number" }
+      ],
+      "responses": {
+        "success": {
+          "status": 200,
+          "description": "Search results",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "success": { "type": "boolean" },
+              "results": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "title": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "errors": [
+          {
+            "status": 400,
+            "description": "Missing query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": { "type": "boolean" },
+                "message": { "type": "string" }
+              }
+            }
+          }
+        ]
+      }
     }
   },
   "implementation": {

--- a/codegen/src/specs/webui/types/api-route-spec.ts
+++ b/codegen/src/specs/webui/types/api-route-spec.ts
@@ -6,4 +6,34 @@ export interface APIRouteSpec {
   route: string;
   method: string;
   description: string;
+  params?: APIRouteParam[];
+  body?: {
+    schema: SchemaDefinition;
+  };
+  responses: {
+    success: ResponseSpec;
+    errors?: ResponseSpec[];
+  };
+}
+
+export interface APIRouteParam {
+  name: string;
+  in: 'query' | 'path';
+  type: SchemaPrimitive;
+  required?: boolean;
+}
+
+export interface ResponseSpec {
+  status: number;
+  description?: string;
+  schema: SchemaDefinition;
+}
+
+export type SchemaPrimitive = 'string' | 'number' | 'boolean';
+
+export interface SchemaDefinition {
+  type: SchemaPrimitive | 'object' | 'array';
+  required?: boolean;
+  properties?: Record<string, SchemaDefinition>;
+  items?: SchemaDefinition;
 }


### PR DESCRIPTION
## Summary
- extend WebUI API route specs with parameters, schemas, and response definitions
- generate Next.js handlers that validate requests, normalize routes, and include stub adapters
- add tests covering success and failure flows for generated API routes

## Testing
- npm test -- src/specs/webui/generator.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adedd2a048331b6df8dc99496a92f)