### PR TITLE
Enhance web UI generator outputs

### DIFF
--- a/codegen/src/specs/webui/generator.test.ts
+++ b/codegen/src/specs/webui/generator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { WebUIGenerator } from './generator';
+import type { ComponentSpec } from './types/component-spec';
+import type { PageSpec } from './types/page-spec';
+import type { WebUIGeneratorSpec } from './types/webui-generator-spec';
+
+const generatorConfig = {
+  uuid: 'test',
+  id: 'interface.webui',
+  search: { title: 'Web UI', summary: 'spec driven' },
+  specsPath: '',
+  outputPath: '',
+} as WebUIGeneratorSpec;
+
+describe('WebUIGenerator component generation', () => {
+  const baseComponentSpec: ComponentSpec = {
+    id: 'webui.component.preview-generate',
+    search: {
+      title: 'Preview/Generate Workflow',
+      summary: 'Select snippet/language and generate preview or artifact',
+    },
+    inputs: [
+      {
+        name: 'snippet',
+        label: 'Snippet or group',
+        type: 'select',
+        placeholder: 'Choose a snippet to render',
+        defaultValue: 'api-handler',
+        options: ['api-handler', 'react-widget', 'cli-tool'],
+      },
+      {
+        name: 'language',
+        label: 'Target language',
+        type: 'select',
+        placeholder: 'Select output language',
+        defaultValue: 'TypeScript',
+        options: ['TypeScript', 'Python', 'Rust', 'Go'],
+      },
+    ],
+    actions: [
+      { name: 'preview', label: 'Generate Preview' },
+      { name: 'generate', label: 'Build Artifact' },
+    ],
+  };
+
+  it('derives prop types, defaults, and JSX bindings from the spec', () => {
+    const generator = new WebUIGenerator(generatorConfig);
+
+    const componentCode = (generator as unknown as { _generateComponentCode: (name: string, spec: ComponentSpec) => string }).
+      _generateComponentCode('preview-generate-workflow', baseComponentSpec);
+
+    expect(componentCode).toContain('GeneratedPreviewGenerateWorkflow');
+    expect(componentCode).toContain('onAction?: (action: ActionName, values: Record<InputName, string>) => void;');
+    expect(componentCode).toContain('const defaultTitle = "Preview/Generate Workflow"');
+    expect(componentCode).toContain('const defaultInputs = {\n  "snippet": "api-handler",\n  "language": "TypeScript"\n}');
+    expect(componentCode).toContain('Build Artifact');
+    expect(componentCode).toContain('language');
+  });
+
+  it('uses pascal-cased component identifiers for page imports and usage', () => {
+    const generator = new WebUIGenerator(generatorConfig);
+    const pageSpec: PageSpec = {
+      uuid: 'page-editor',
+      id: 'webui.page.editor',
+      route: '/editor',
+      components: ['preview-generate-workflow'],
+    };
+    const pageCode = (generator as unknown as {
+      _generatePageCode: (name: string, page: PageSpec, components: Record<string, ComponentSpec>) => string;
+    })._generatePageCode('editor', pageSpec, {
+      'preview-generate-workflow': baseComponentSpec,
+    });
+
+    expect(pageCode).toContain("import { GeneratedPreviewGenerateWorkflow } from '../../components/generated-preview-generate-workflow';");
+    expect(pageCode).toContain('<GeneratedPreviewGenerateWorkflow />');
+  });
+});

--- a/codegen/src/specs/webui/generator.ts
+++ b/codegen/src/specs/webui/generator.ts
@@ -135,6 +135,18 @@ export class WebUIGenerator {
    * @param componentSpec
    */
   private _generateComponentCode(componentName: string, componentSpec: ComponentSpec): string {
+    const pascalName = WebUIGenerator.pascalCase(componentName);
+    const inputDefinitions = JSON.stringify(componentSpec.inputs ?? [], null, 2);
+    const actionDefinitions = JSON.stringify(componentSpec.actions ?? [], null, 2);
+    const defaultInputs = JSON.stringify(
+      (componentSpec.inputs ?? []).reduce<Record<string, string>>((acc, input) => {
+        acc[input.name] = input.defaultValue ?? '';
+        return acc;
+      }, {}),
+      null,
+      2,
+    );
+
     return `/**
  * Generated ${componentSpec.search.title}
  *
@@ -143,23 +155,148 @@ export class WebUIGenerator {
  * Auto-generated from spec.json
  */
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
-interface Generated${componentName.charAt(0).toUpperCase() + componentName.slice(1)}Props {
-  // TODO: Define props based on spec
+const inputDefinitions = ${inputDefinitions} as const;
+const actionDefinitions = ${actionDefinitions} as const;
+
+type InputName = (typeof inputDefinitions)[number] extends { name: infer N } ? N : never;
+type ActionName = (typeof actionDefinitions)[number] extends { name: infer N } ? N : never;
+
+interface Generated${pascalName}Props {
+  /** Override the default title derived from the spec search metadata */
+  title?: string;
+  /** Override the default summary derived from the spec search metadata */
+  summary?: string;
+  /** Provide initial input values mapped by the spec input names */
+  inputs?: Partial<Record<InputName, string>>;
+  /** Override action labels mapped by the spec action names */
+  actions?: Partial<Record<ActionName, string>>;
+  /** Input change callback invoked with the spec-defined input name and current value */
+  onInputChange?: (name: InputName, value: string) => void;
+  /** Action callback invoked with the action name and the current form values */
+  onAction?: (action: ActionName, values: Record<InputName, string>) => void;
 }
 
-export const Generated${componentName.charAt(0).toUpperCase() + componentName.slice(1)}: React.FC<Generated${componentName.charAt(0).toUpperCase() + componentName.slice(1)}Props> = (props) => {
+const defaultTitle = ${JSON.stringify(componentSpec.search.title)};
+const defaultSummary = ${JSON.stringify(componentSpec.search.summary)};
+const defaultInputs = ${defaultInputs} as Record<InputName, string>;
+
+export const Generated${pascalName}: React.FC<Generated${pascalName}Props> = ({
+  title = defaultTitle,
+  summary = defaultSummary,
+  inputs = {} as Partial<Record<InputName, string>>,
+  actions: actionOverrides = {} as Partial<Record<ActionName, string>>,
+  onInputChange,
+  onAction,
+}) => {
+  const [formValues, setFormValues] = useState<Record<InputName, string>>({
+    ...defaultInputs,
+    ...(inputs as Partial<Record<InputName, string>>),
+  });
+
+  const hasInputs = useMemo(() => inputDefinitions.length > 0, []);
+  const hasActions = useMemo(() => actionDefinitions.length > 0, []);
+
+  const handleInputChange = (name: InputName, value: string) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    onInputChange?.(name, value);
+  };
+
+  const handleAction = (action: ActionName) => {
+    onAction?.(action, formValues);
+  };
+
   return (
-    <div>
-      <h2>${componentSpec.search.title}</h2>
-      <p>${componentSpec.search.summary}</p>
-      {/* TODO: Implement component based on spec capabilities */}
-    </div>
+    <section aria-label={title} className="generated-component">
+      <header>
+        <h2>{title}</h2>
+        <p>{summary}</p>
+      </header>
+
+      {hasInputs && (
+        <div className="generated-inputs" role="form">
+          {inputDefinitions.map((input) => {
+            const value = formValues[input.name as InputName] ?? '';
+            const inputId = '${componentName}-input-' + String(input.name);
+
+            if (input.type === 'select' && input.options?.length) {
+              return (
+                <label key={input.name} htmlFor={inputId} className="generated-input">
+                  <span className="generated-input__label">{input.label}</span>
+                  <select
+                    id={inputId}
+                    value={value ?? ''}
+                    onChange={(event) => handleInputChange(input.name as InputName, event.target.value)}
+                  >
+                    <option value="" disabled>
+                      {input.placeholder ?? 'Select an option'}
+                    </option>
+                    {input.options.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  {input.helperText && <small className="generated-input__help">{input.helperText}</small>}
+                </label>
+              );
+            }
+
+            if (input.type === 'textarea') {
+              return (
+                <label key={input.name} htmlFor={inputId} className="generated-input">
+                  <span className="generated-input__label">{input.label}</span>
+                  <textarea
+                    id={inputId}
+                    placeholder={input.placeholder}
+                    value={value ?? ''}
+                    onChange={(event) => handleInputChange(input.name as InputName, event.target.value)}
+                  />
+                  {input.helperText && <small className="generated-input__help">{input.helperText}</small>}
+                </label>
+              );
+            }
+
+            return (
+              <label key={input.name} htmlFor={inputId} className="generated-input">
+                <span className="generated-input__label">{input.label}</span>
+                <input
+                  id={inputId}
+                  type={input.type ?? 'text'}
+                  placeholder={input.placeholder}
+                  value={value ?? ''}
+                  onChange={(event) => handleInputChange(input.name as InputName, event.target.value)}
+                />
+                {input.helperText && <small className="generated-input__help">{input.helperText}</small>}
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      {hasActions && (
+        <div className="generated-actions" role="group" aria-label="Actions">
+          {actionDefinitions.map((action) => (
+            <button
+              key={action.name}
+              type="button"
+              onClick={() => handleAction(action.name as ActionName)}
+              aria-label={action.helperText ?? action.label}
+            >
+              {actionOverrides[action.name as ActionName] ?? action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
   );
 };
 
-export default Generated${componentName.charAt(0).toUpperCase() + componentName.slice(1)};`;
+export default Generated${pascalName};`;
   }
 
   /**
@@ -176,11 +313,11 @@ export default Generated${componentName.charAt(0).toUpperCase() + componentName.
     const imports = pageSpec.components
         .map(
           (comp) =>
-            `import { Generated${comp.charAt(0).toUpperCase() + comp.slice(1)} } from '../../components/generated-${comp}';`,
+            `import { Generated${WebUIGenerator.pascalCase(comp)} } from '../../components/generated-${comp}';`,
         )
         .join('\n'),
       componentUsage = pageSpec.components
-        .map((comp) => `      <Generated${comp.charAt(0).toUpperCase() + comp.slice(1)} />`)
+        .map((comp) => `      <Generated${WebUIGenerator.pascalCase(comp)} />`)
         .join('\n');
 
     return `/**
@@ -198,7 +335,7 @@ export default function ${pageName.charAt(0).toUpperCase() + pageName.slice(1)}P
       <h1>${pageName.charAt(0).toUpperCase() + pageName.slice(1)} Page</h1>
 ${componentUsage}
     </div>
-  );
+ );
 }`;
   }
 
@@ -232,6 +369,14 @@ export async function ${apiSpec.method.toUpperCase()}(request: NextRequest) {
     }, { status: 500 });
   }
 }`;
+  }
+
+  private static pascalCase(value: string): string {
+    return value
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join('');
   }
 
   /**

--- a/codegen/src/specs/webui/spec.json
+++ b/codegen/src/specs/webui/spec.json
@@ -102,6 +102,38 @@
         "keywords": ["preview", "generate", "workflow", "artifact", "zip", "tar"],
         "domain": "codegen"
       },
+      "inputs": [
+        {
+          "name": "snippet",
+          "label": "Snippet or group",
+          "type": "select",
+          "placeholder": "Choose a snippet to render",
+          "defaultValue": "api-handler",
+          "options": ["api-handler", "react-widget", "cli-tool"],
+          "helperText": "Pick the snippet or collection you want to preview"
+        },
+        {
+          "name": "language",
+          "label": "Target language",
+          "type": "select",
+          "placeholder": "Select output language",
+          "defaultValue": "TypeScript",
+          "options": ["TypeScript", "Python", "Rust", "Go"],
+          "helperText": "Language passed to preview and generation requests"
+        }
+      ],
+      "actions": [
+        {
+          "name": "preview",
+          "label": "Generate Preview",
+          "helperText": "Generate a quick preview without saving an artifact"
+        },
+        {
+          "name": "generate",
+          "label": "Build Artifact",
+          "helperText": "Trigger backend build to produce zip/tarball"
+        }
+      ],
       "features": [
         "select snippet/group + language → render generated preview",
         "generate action produces artifact (zip/tarball) via backend API route",

--- a/codegen/src/specs/webui/types/component-spec.ts
+++ b/codegen/src/specs/webui/types/component-spec.ts
@@ -7,6 +7,8 @@ export interface ComponentSpec {
     title: string;
     summary: string;
   };
+  inputs?: ComponentInputSpec[];
+  actions?: ComponentActionSpec[];
   features?: string[];
   capabilities?: string[];
   searchFields?: string[];
@@ -14,4 +16,20 @@ export interface ComponentSpec {
     name: string;
     values: string[];
   }[];
+}
+
+export interface ComponentInputSpec {
+  name: string;
+  label: string;
+  type?: 'text' | 'select' | 'textarea';
+  placeholder?: string;
+  defaultValue?: string;
+  helperText?: string;
+  options?: string[];
+}
+
+export interface ComponentActionSpec {
+  name: string;
+  label: string;
+  helperText?: string;
 }

--- a/codegen/src/webui/components/generated-preview-generate-workflow.tsx
+++ b/codegen/src/webui/components/generated-preview-generate-workflow.tsx
@@ -6,19 +6,151 @@
  * Auto-generated from spec.json
  */
 
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+
+type InputName = 'snippet' | 'language';
+type ActionName = 'preview' | 'generate';
 
 interface GeneratedPreviewGenerateWorkflowProps {
-  // TODO: Define props based on spec
+  title?: string;
+  summary?: string;
+  inputs?: Partial<Record<InputName, string>>;
+  actions?: Partial<Record<ActionName, string>>;
+  onInputChange?: (name: InputName, value: string) => void;
+  onAction?: (action: ActionName, values: Record<InputName, string>) => void;
 }
 
-const GeneratedPreviewGenerateWorkflow: React.FC<GeneratedPreviewGenerateWorkflowProps> = () => {
+const inputDefinitions: Array<{
+  name: InputName;
+  label: string;
+  type: 'select';
+  placeholder: string;
+  defaultValue: string;
+  options: string[];
+  helperText: string;
+}> = [
+  {
+    name: 'snippet',
+    label: 'Snippet or group',
+    type: 'select',
+    placeholder: 'Choose a snippet to render',
+    defaultValue: 'api-handler',
+    options: ['api-handler', 'react-widget', 'cli-tool'],
+    helperText: 'Pick the snippet or collection you want to preview',
+  },
+  {
+    name: 'language',
+    label: 'Target language',
+    type: 'select',
+    placeholder: 'Select output language',
+    defaultValue: 'TypeScript',
+    options: ['TypeScript', 'Python', 'Rust', 'Go'],
+    helperText: 'Language passed to preview and generation requests',
+  },
+];
+
+const actionDefinitions: Array<{
+  name: ActionName;
+  label: string;
+  helperText?: string;
+}> = [
+  {
+    name: 'preview',
+    label: 'Generate Preview',
+    helperText: 'Generate a quick preview without saving an artifact',
+  },
+  {
+    name: 'generate',
+    label: 'Build Artifact',
+    helperText: 'Trigger backend build to produce zip/tarball',
+  },
+];
+
+const defaultTitle = 'Preview/Generate Workflow';
+const defaultSummary = 'Select snippet/language and generate preview or artifact';
+
+const GeneratedPreviewGenerateWorkflow: React.FC<GeneratedPreviewGenerateWorkflowProps> = ({
+  title = defaultTitle,
+  summary = defaultSummary,
+  inputs = {},
+  actions: actionOverrides = {},
+  onInputChange,
+  onAction,
+}) => {
+  const defaultInputs = useMemo(
+    () =>
+      inputDefinitions.reduce<Record<InputName, string>>((acc, input) => {
+        acc[input.name] = input.defaultValue;
+        return acc;
+      }, {} as Record<InputName, string>),
+    [],
+  );
+
+  const [formValues, setFormValues] = useState<Record<InputName, string>>({
+    ...defaultInputs,
+    ...inputs,
+  });
+
+  const handleInputChange = (name: InputName, value: string) => {
+    setFormValues((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    onInputChange?.(name, value);
+  };
+
+  const handleAction = (action: ActionName) => {
+    onAction?.(action, formValues);
+  };
+
   return (
-    <div>
-      <h2>Preview/Generate Workflow</h2>
-      <p>Select snippet/language and generate preview or artifact</p>
-      {/* TODO: Implement component based on spec capabilities */}
-    </div>
+    <section aria-label={title} className="generated-component">
+      <header>
+        <h2>{title}</h2>
+        <p>{summary}</p>
+      </header>
+
+      <div className="generated-inputs" role="form">
+        {inputDefinitions.map((input) => {
+          const value = formValues[input.name] ?? '';
+          const inputId = `preview-generate-workflow-${input.name}`;
+
+          return (
+            <label key={input.name} htmlFor={inputId} className="generated-input">
+              <span className="generated-input__label">{input.label}</span>
+              <select
+                id={inputId}
+                value={value}
+                onChange={(event) => handleInputChange(input.name, event.target.value)}
+              >
+                <option value="" disabled>
+                  {input.placeholder}
+                </option>
+                {input.options.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+              {input.helperText && <small className="generated-input__help">{input.helperText}</small>}
+            </label>
+          );
+        })}
+      </div>
+
+      <div className="generated-actions" role="group" aria-label="Actions">
+        {actionDefinitions.map((action) => (
+          <button
+            key={action.name}
+            type="button"
+            onClick={() => handleAction(action.name)}
+            aria-label={action.helperText ?? action.label}
+          >
+            {actionOverrides[action.name] ?? action.label}
+          </button>
+        ))}
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- derive generated component props, defaults, and JSX bindings directly from Web UI component specs
- enrich the preview/generate workflow spec and generated component with actionable inputs and callbacks
- add generator-focused unit coverage to validate props, defaults, and pascal-cased imports

## Testing
- npm test -- src/specs/webui/generator.test.ts
- npm test *(fails: existing suite errors about missing core base-component/module imports)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adeacb4dc83319bd6b6ecce9a147d)