### PR TITLE
Enhance docs viewer with rich markdown navigation

### DIFF
--- a/docs-viewer/README.md
+++ b/docs-viewer/README.md
@@ -36,8 +36,15 @@ npm run dev
 
 1. **Navigation** — `DocsNavigation` reads `DOCS_STRUCTURE` to build a collapsible list grouped by section. It highlights the active document and notifies the parent when a user picks another file.【F:docs-viewer/src/components/docs-navigation.tsx†L15-L75】
 2. **Page state** — The home page (`src/app/page.tsx`) tracks the active section/file, fetches markdown when they change, and handles loading/error UI. The first section/file is selected by default so content appears immediately.【F:docs-viewer/src/app/page.tsx†L1-L86】
-3. **Rendering** — `MarkdownViewer` wraps `react-markdown` inside a styled Material UI `Paper` element. It tunes typography, code blocks, blockquotes, and tables to keep docs readable.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L88】
+3. **Rendering** — `MarkdownViewer` wraps `react-markdown` inside a styled Material UI `Paper` element. It tunes typography, code blocks, blockquotes, tables, footnotes, wiki-style crosslinks, and adds automatic anchor IDs so a table of contents can deep-link into the page.【F:docs-viewer/src/components/markdown-viewer.tsx†L1-L197】【F:docs-viewer/src/lib/markdown-headings.ts†L1-L56】
 4. **Theming** — `Providers` configures a light Material UI theme with project fonts and baseline styles, keeping the viewer visually consistent.【F:docs-viewer/src/components/providers.tsx†L1-L27】
+
+## Rich reading features
+
+- **Table of contents**: `extractHeadings` builds a linked TOC from `h1`–`h4` headings so readers can jump around long articles.【F:docs-viewer/src/lib/markdown-headings.ts†L1-L56】【F:docs-viewer/src/components/table-of-contents.tsx†L1-L48】
+- **In-page navigation**: A pager surfaces previous/next documents in catalogue order for quick scanning.【F:docs-viewer/src/components/doc-pager.tsx†L1-L62】【F:docs-viewer/src/lib/doc-links.ts†L1-L51】
+- **Wiki-style links**: Authors can reference other docs using `[[Document Title]]`; the viewer resolves and routes to the target file when clicked.【F:docs-viewer/src/components/markdown-viewer.tsx†L51-L153】【F:docs-viewer/src/lib/doc-links.ts†L1-L24】
+- **Footnotes and references**: `remark-gfm` enables footnotes and Harvard-style reference lists, with extra styling to keep citations readable.【F:docs-viewer/src/components/markdown-viewer.tsx†L27-L120】
 
 ## Adding or updating documentation
 

--- a/docs-viewer/package.json
+++ b/docs-viewer/package.json
@@ -16,16 +16,22 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",
+    "github-slugger": "^2.0.0",
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/mdast": "^4.0.4",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",

--- a/docs-viewer/src/app/page.tsx
+++ b/docs-viewer/src/app/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Box, Container, Typography, CircularProgress } from "@mui/material";
 import { DocsNavigation } from "@/components/docs-navigation";
 import { MarkdownViewer } from "@/components/markdown-viewer";
+import { TableOfContents } from "@/components/table-of-contents";
+import { DocPager } from "@/components/doc-pager";
 import { DOCS_STRUCTURE, getDocFile } from "@/lib/docs-structure";
+import { extractHeadings } from "@/lib/markdown-headings";
+import { getAdjacentDocs } from "@/lib/doc-links";
 
 export default function Home() {
   const [currentSection, setCurrentSection] = useState<string>(
@@ -16,6 +20,7 @@ export default function Home() {
   const [content, setContent] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const headings = useMemo(() => extractHeadings(content), [content]);
 
   const loadDocument = async (sectionId: string, fileId: string) => {
     setLoading(true);
@@ -54,6 +59,7 @@ export default function Home() {
   };
 
   const currentDocFile = getDocFile(currentSection, currentFile);
+  const adjacentDocs = getAdjacentDocs(currentSection, currentFile);
 
   return (
     <Box sx={{ display: "flex", minHeight: "100vh" }}>
@@ -85,13 +91,23 @@ export default function Home() {
               </Typography>
             </Box>
           ) : (
-            <MarkdownViewer
-              content={content}
-              title={currentDocFile?.title}
-            />
+            <>
+              <MarkdownViewer
+                content={content}
+                title={currentDocFile?.title}
+                headings={headings}
+                onNavigateDoc={handleFileSelect}
+              />
+              <DocPager
+                previous={adjacentDocs.previous}
+                next={adjacentDocs.next}
+                onNavigate={handleFileSelect}
+              />
+            </>
           )}
         </Container>
       </Box>
+      <TableOfContents headings={headings} />
     </Box>
   );
 }

--- a/docs-viewer/src/components/doc-pager.tsx
+++ b/docs-viewer/src/components/doc-pager.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import type { DocFile } from "@/types/docs";
+
+interface DocPagerProps {
+  previous?: DocFile;
+  next?: DocFile;
+  onNavigate: (sectionId: string, fileId: string) => void;
+}
+
+export function DocPager({ previous, next, onNavigate }: DocPagerProps) {
+  if (!previous && !next) return null;
+
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      justifyContent="space-between"
+      spacing={2}
+      sx={{ mt: 4, pt: 3, borderTop: "1px solid", borderColor: "divider" }}
+    >
+      <Box flex={1}>
+        {previous ? (
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBackIcon />}
+            onClick={() => onNavigate(previous.section, previous.id)}
+            sx={{ textAlign: "left" }}
+          >
+            <Typography variant="caption" component="div" color="text.secondary">
+              Previous
+            </Typography>
+            <Typography variant="body2" fontWeight={600} component="div">
+              {previous.title}
+            </Typography>
+          </Button>
+        ) : null}
+      </Box>
+
+      <Box flex={1} textAlign="right">
+        {next ? (
+          <Button
+            variant="contained"
+            endIcon={<ArrowForwardIcon />}
+            onClick={() => onNavigate(next.section, next.id)}
+            sx={{ textAlign: "right" }}
+          >
+            <Box textAlign="right">
+              <Typography
+                variant="caption"
+                component="div"
+                color="text.secondary"
+                sx={{ lineHeight: 1.2 }}
+              >
+                Next
+              </Typography>
+              <Typography variant="body2" fontWeight={600} component="div">
+                {next.title}
+              </Typography>
+            </Box>
+          </Button>
+        ) : null}
+      </Box>
+    </Stack>
+  );
+}

--- a/docs-viewer/src/components/markdown-viewer.tsx
+++ b/docs-viewer/src/components/markdown-viewer.tsx
@@ -1,18 +1,47 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
-import { Typography, Paper } from "@mui/material";
+import remarkGfm from "remark-gfm";
+import {
+  Box,
+  Chip,
+  Divider,
+  Link,
+  Paper,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import type { HeadingItem } from "@/lib/markdown-headings";
+import type { DocLinkTarget } from "@/lib/doc-links";
+import { findDocLink } from "@/lib/doc-links";
 
 interface MarkdownViewerProps {
   content: string;
   title?: string;
+  headings: HeadingItem[];
+  onNavigateDoc?: (sectionId: string, fileId: string) => void;
 }
 
 export function MarkdownViewer({
   content,
   title,
+  headings,
+  onNavigateDoc,
 }: MarkdownViewerProps): React.JSX.Element {
+  const wikiReadyContent = useMemo(
+    () => content.replace(/\[\[([^\]]+)\]\]/g, "[$1](doc:$1)"),
+    [content]
+  );
+
+  let headingRenderIndex = 0;
+
+  const handleDocLink = (target?: DocLinkTarget) => (event: React.MouseEvent) => {
+    if (!target || !onNavigateDoc) return;
+    event.preventDefault();
+    onNavigateDoc(target.sectionId, target.fileId);
+  };
+
   return (
     <Paper
       elevation={0}
@@ -97,6 +126,24 @@ export function MarkdownViewer({
           fontStyle: "italic",
           mb: 2,
         },
+        "& .footnotes": {
+          borderTop: "1px solid",
+          borderColor: "divider",
+          mt: 4,
+          pt: 2,
+          "& ol": {
+            pl: 3,
+            mb: 0,
+          },
+          "& li": {
+            mb: 1.5,
+            lineHeight: 1.6,
+          },
+        },
+        "& sup.footnote-ref": {
+          fontSize: "0.75rem",
+          ml: 0.25,
+        },
         "& table": {
           width: "100%",
           borderCollapse: "collapse",
@@ -128,7 +175,96 @@ export function MarkdownViewer({
           {title}
         </Typography>
       ) : null}
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => {
+            const headingId = headings[headingRenderIndex]?.id;
+            headingRenderIndex += 1;
+
+            return (
+              <Typography id={headingId} variant="h2" component="h2">
+                {children}
+              </Typography>
+            );
+          },
+          h2: ({ children }) => {
+            const headingId = headings[headingRenderIndex]?.id;
+            headingRenderIndex += 1;
+
+            return (
+              <Box id={headingId}>
+                <Divider sx={{ mb: 1 }} />
+                <Typography variant="h3" component="h3">
+                  {children}
+                </Typography>
+              </Box>
+            );
+          },
+          h3: ({ children }) => {
+            const headingId = headings[headingRenderIndex]?.id;
+            headingRenderIndex += 1;
+
+            return (
+              <Typography id={headingId} variant="h4" component="h4">
+                {children}
+              </Typography>
+            );
+          },
+          h4: ({ children }) => {
+            const headingId = headings[headingRenderIndex]?.id;
+            headingRenderIndex += 1;
+
+            return (
+              <Typography id={headingId} variant="h5" component="h5">
+                {children}
+              </Typography>
+            );
+          },
+          a: ({ href, children }) => {
+            if (href?.startsWith("doc:")) {
+              const label = href.replace("doc:", "");
+              const target = findDocLink(label);
+              const isUnresolved = target == null;
+
+              return (
+                <Tooltip title={isUnresolved ? "Document not found" : "Navigate"}>
+                  <span>
+                    <Link
+                      component="button"
+                      color={isUnresolved ? "text.secondary" : "primary"}
+                      onClick={handleDocLink(target)}
+                      underline="hover"
+                      sx={{
+                        cursor: isUnresolved ? "not-allowed" : "pointer",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 0.5,
+                      }}
+                    >
+                      {children}
+                      <Chip
+                        size="small"
+                        label={isUnresolved ? "missing" : target?.title ?? "link"}
+                        color={isUnresolved ? "default" : "secondary"}
+                        variant="outlined"
+                      />
+                    </Link>
+                  </span>
+                </Tooltip>
+              );
+            }
+
+            return (
+              <Link href={href} underline="hover">
+                {children}
+              </Link>
+            );
+          },
+        }}
+      >
+        {wikiReadyContent}
+      </ReactMarkdown>
     </Paper>
   );
 }

--- a/docs-viewer/src/components/table-of-contents.tsx
+++ b/docs-viewer/src/components/table-of-contents.tsx
@@ -1,0 +1,53 @@
+import { Box, Typography, List, ListItemButton, ListItemText } from "@mui/material";
+import type { HeadingItem } from "@/lib/markdown-headings";
+
+interface TableOfContentsProps {
+  headings: HeadingItem[];
+}
+
+export function TableOfContents({ headings }: TableOfContentsProps) {
+  if (!headings.length) return null;
+
+  return (
+    <Box
+      component="nav"
+      aria-label="Table of contents"
+      sx={{
+        width: 280,
+        borderLeft: "1px solid",
+        borderColor: "divider",
+        display: { xs: "none", lg: "block" },
+        position: "sticky",
+        top: 0,
+        maxHeight: "100vh",
+        overflowY: "auto",
+        bgcolor: "background.paper",
+        p: 2,
+      }}
+    >
+      <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+        On this page
+      </Typography>
+      <List dense>
+        {headings.map((heading) => (
+          <ListItemButton
+            key={heading.id}
+            component="a"
+            href={`#${heading.id}`}
+            sx={{
+              pl: heading.level > 2 ? (heading.level - 1) * 2 : 2,
+              borderLeft: "2px solid",
+              borderColor: "transparent",
+              "&:hover": { borderColor: "primary.main" },
+            }}
+          >
+            <ListItemText
+              primaryTypographyProps={{ variant: "body2" }}
+              primary={heading.title}
+            />
+          </ListItemButton>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/docs-viewer/src/lib/doc-links.ts
+++ b/docs-viewer/src/lib/doc-links.ts
@@ -1,0 +1,59 @@
+import { DOCS_STRUCTURE } from "@/lib/docs-structure";
+import type { DocFile } from "@/types/docs";
+
+export interface DocLinkTarget {
+  sectionId: string;
+  fileId: string;
+  title: string;
+}
+
+export interface AdjacentDocs {
+  previous?: DocFile;
+  next?: DocFile;
+}
+
+export function findDocLink(label: string): DocLinkTarget | undefined {
+  const normalized = label.trim().toLowerCase();
+
+  for (const section of DOCS_STRUCTURE) {
+    for (const file of section.files) {
+      const titleMatch = file.title.toLowerCase() === normalized;
+      const idMatch = file.id.toLowerCase() === normalized;
+      const compositeMatch = `${section.title.toLowerCase()} / ${file.title.toLowerCase()}` === normalized;
+
+      if (titleMatch || idMatch || compositeMatch) {
+        return {
+          sectionId: section.id,
+          fileId: file.id,
+          title: file.title,
+        };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getAdjacentDocs(
+  sectionId: string,
+  fileId: string
+): AdjacentDocs {
+  const orderedFiles: DocFile[] = [];
+
+  DOCS_STRUCTURE.forEach((section) => {
+    orderedFiles.push(...section.files);
+  });
+
+  const currentIndex = orderedFiles.findIndex(
+    (doc) => doc.section === sectionId && doc.id === fileId
+  );
+
+  if (currentIndex === -1) {
+    return {};
+  }
+
+  return {
+    previous: orderedFiles[currentIndex - 1],
+    next: orderedFiles[currentIndex + 1],
+  };
+}

--- a/docs-viewer/src/lib/markdown-headings.ts
+++ b/docs-viewer/src/lib/markdown-headings.ts
@@ -1,0 +1,58 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import GithubSlugger from "github-slugger";
+import { visit } from "unist-util-visit";
+import type { Heading, PhrasingContent } from "mdast";
+
+export interface HeadingItem {
+  id: string;
+  title: string;
+  level: number;
+}
+
+const TEXT_NODES = new Set([
+  "text",
+  "inlineCode",
+  "emphasis",
+  "strong",
+  "link",
+  "delete",
+]);
+
+function extractTextFromChildren(children: PhrasingContent[]): string {
+  return children
+    .map((child) => {
+      if (child.type === "text" || child.type === "inlineCode") {
+        return child.value;
+      }
+
+      if (TEXT_NODES.has(child.type)) {
+        return extractTextFromChildren((child as any).children ?? []);
+      }
+
+      return "";
+    })
+    .join(" ")
+    .trim();
+}
+
+export function extractHeadings(markdown: string): HeadingItem[] {
+  const tree = unified().use(remarkParse).parse(markdown);
+  const slugger = new GithubSlugger();
+  const headings: HeadingItem[] = [];
+
+  visit(tree, "heading", (node: Heading) => {
+    if (node.depth > 4) return;
+
+    const title = extractTextFromChildren(node.children);
+    if (!title) return;
+
+    headings.push({
+      id: slugger.slug(title),
+      title,
+      level: node.depth,
+    });
+  });
+
+  return headings;
+}


### PR DESCRIPTION
## Summary
- add heading extraction and TOC support plus wiki-style doc links and footnote styling to the markdown renderer
- provide adjacent-document pager and helper utilities for resolving doc links
- document the richer reading experience and required markdown dependencies

## Testing
- npm run lint *(fails: existing ESLint configuration reports numerous style and TypeScript rule violations across the project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae176312c833196e792f4ddc2d1b0)