### PR TITLE
Fix HeroSection lifecycle status import

### DIFF
--- a/retro-react-app/src/components/hero-section.tsx
+++ b/retro-react-app/src/components/hero-section.tsx
@@ -4,10 +4,8 @@ import { Box, Chip, Typography, Stack, Button } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import React, { useRef } from "react";
-import type {
-  IReactComponentLifecycle,
-  ComponentLifecycleStatus
-} from "@/lib/lifecycle-manager";
+import { ComponentLifecycleStatus } from "@/lib/lifecycle-manager";
+import type { IReactComponentLifecycle } from "@/lib/lifecycle-manager";
 import componentPatterns from "@/lib/component-patterns.json";
 
 // SVG Console Icon Component - now uses extracted patterns


### PR DESCRIPTION
## Summary
- ensure ComponentLifecycleStatus is imported as a runtime value in HeroSection lifecycle

## Testing
- bunx vitest run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae3250d048331b51db35299b1ae73)