### PR TITLE
Refactor webui interfaces into dedicated files

### DIFF
--- a/codegen/src/specs/webui/generator.ts
+++ b/codegen/src/specs/webui/generator.ts
@@ -7,12 +7,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { ISpec } from '../../core/interfaces';
-import type {
-  APIRouteParam,
-  APIRouteSpec,
-  ResponseSpec,
-  SchemaDefinition,
-} from './types/api-route-spec';
+import type { APIRouteParam } from './types/api-route-param';
+import type { APIRouteSpec } from './types/api-route-spec';
+import type { ResponseSpec } from './types/response-spec';
+import type { SchemaDefinition } from './types/schema-definition';
 import type { ComponentSpec } from './types/component-spec';
 import type { ExecutionResult } from './types/execution-result';
 import type { GeneratedFile } from './types/generated-file';

--- a/codegen/src/specs/webui/types/api-route-param.ts
+++ b/codegen/src/specs/webui/types/api-route-param.ts
@@ -1,0 +1,11 @@
+/**
+ * API route parameter definition
+ */
+export interface APIRouteParam {
+  name: string;
+  in: 'query' | 'path';
+  type: SchemaPrimitive;
+  required?: boolean;
+}
+
+export type SchemaPrimitive = 'string' | 'number' | 'boolean';

--- a/codegen/src/specs/webui/types/api-route-spec.ts
+++ b/codegen/src/specs/webui/types/api-route-spec.ts
@@ -1,3 +1,7 @@
+import type { APIRouteParam } from './api-route-param';
+import type { ResponseSpec } from './response-spec';
+import type { SchemaDefinition } from './schema-definition';
+
 /**
  * Specification for a generated API route
  */
@@ -14,26 +18,4 @@ export interface APIRouteSpec {
     success: ResponseSpec;
     errors?: ResponseSpec[];
   };
-}
-
-export interface APIRouteParam {
-  name: string;
-  in: 'query' | 'path';
-  type: SchemaPrimitive;
-  required?: boolean;
-}
-
-export interface ResponseSpec {
-  status: number;
-  description?: string;
-  schema: SchemaDefinition;
-}
-
-export type SchemaPrimitive = 'string' | 'number' | 'boolean';
-
-export interface SchemaDefinition {
-  type: SchemaPrimitive | 'object' | 'array';
-  required?: boolean;
-  properties?: Record<string, SchemaDefinition>;
-  items?: SchemaDefinition;
 }

--- a/codegen/src/specs/webui/types/response-spec.ts
+++ b/codegen/src/specs/webui/types/response-spec.ts
@@ -1,0 +1,10 @@
+import type { SchemaDefinition } from './schema-definition';
+
+/**
+ * API response specification
+ */
+export interface ResponseSpec {
+  status: number;
+  description?: string;
+  schema: SchemaDefinition;
+}

--- a/codegen/src/specs/webui/types/schema-definition.ts
+++ b/codegen/src/specs/webui/types/schema-definition.ts
@@ -1,0 +1,11 @@
+import type { SchemaPrimitive } from './api-route-param';
+
+/**
+ * Schema definition for request/response bodies
+ */
+export interface SchemaDefinition {
+  type: SchemaPrimitive | 'object' | 'array';
+  required?: boolean;
+  properties?: Record<string, SchemaDefinition>;
+  items?: SchemaDefinition;
+}

--- a/codegen/src/webui/components/generated-full-text-search.tsx
+++ b/codegen/src/webui/components/generated-full-text-search.tsx
@@ -30,30 +30,9 @@ import {
   Search as SearchIcon,
   FilterList as FilterIcon,
 } from '@mui/icons-material';
-
-interface SearchResult {
-  id: string;
-  title: string;
-  summary: string;
-  domain: string;
-  type: string;
-  score: number;
-  highlights: string[];
-}
-
-interface SearchFilters {
-  domain?: string;
-  platform?: string;
-  language?: string;
-  type?: string;
-}
-
-interface GeneratedFullTextSearchProps {
-  onResultSelect?: (resultId: string) => void;
-  placeholder?: string;
-  filters?: SearchFilters;
-  onFiltersChange?: (filters: SearchFilters) => void;
-}
+import type { GeneratedFullTextSearchProps } from './types/generated-full-text-search-props';
+import type { SearchFilters } from './types/search-filters';
+import type { SearchResult } from './types/search-result';
 
 const mockSearchResults: SearchResult[] = [
   {

--- a/codegen/src/webui/components/generated-tree-navigation.tsx
+++ b/codegen/src/webui/components/generated-tree-navigation.tsx
@@ -11,30 +11,8 @@ import { Description as DescriptionIcon, Folder as FolderIcon } from '@mui/icons
 import { Box, Chip, Paper, Typography } from '@mui/material';
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
 import React, { useState } from 'react';
-
-/**
- * A node that can be rendered inside the generated tree navigation.
- */
-interface TreeNode {
-  id: string;
-  name: string;
-  type: 'aggregate' | 'registry' | 'component' | 'tool' | 'profile';
-  children?: TreeNode[];
-  metadata?: {
-    count?: number;
-    status?: string;
-    domain?: string;
-  };
-}
-
-/**
- * Props passed to the generated tree navigation component.
- */
-interface GeneratedTreeNavigationProps {
-  data: TreeNode[];
-  onNodeSelect?: (nodeId: string) => void;
-  selectedNodeId: string | undefined;
-}
+import type { GeneratedTreeNavigationProps } from './types/generated-tree-navigation-props';
+import type { TreeNode } from './types/tree-node';
 
 const hasChildNodes = (node: TreeNode): boolean =>
   Array.isArray(node.children) && node.children.length > 0;

--- a/codegen/src/webui/components/types/generated-full-text-search-props.ts
+++ b/codegen/src/webui/components/types/generated-full-text-search-props.ts
@@ -1,0 +1,11 @@
+import type { SearchFilters } from './search-filters';
+
+/**
+ * Props for the generated full-text search component
+ */
+export interface GeneratedFullTextSearchProps {
+  onResultSelect?: (resultId: string) => void;
+  placeholder?: string;
+  filters?: SearchFilters;
+  onFiltersChange?: (filters: SearchFilters) => void;
+}

--- a/codegen/src/webui/components/types/generated-tree-navigation-props.ts
+++ b/codegen/src/webui/components/types/generated-tree-navigation-props.ts
@@ -1,0 +1,10 @@
+import type { TreeNode } from './tree-node';
+
+/**
+ * Props passed to the generated tree navigation component.
+ */
+export interface GeneratedTreeNavigationProps {
+  data: TreeNode[];
+  onNodeSelect?: (nodeId: string) => void;
+  selectedNodeId: string | undefined;
+}

--- a/codegen/src/webui/components/types/search-filters.ts
+++ b/codegen/src/webui/components/types/search-filters.ts
@@ -1,0 +1,9 @@
+/**
+ * Filter options applied to search results
+ */
+export interface SearchFilters {
+  domain?: string;
+  platform?: string;
+  language?: string;
+  type?: string;
+}

--- a/codegen/src/webui/components/types/search-result.ts
+++ b/codegen/src/webui/components/types/search-result.ts
@@ -1,0 +1,12 @@
+/**
+ * Represents a search result displayed in the generated UI
+ */
+export interface SearchResult {
+  id: string;
+  title: string;
+  summary: string;
+  domain: string;
+  type: string;
+  score: number;
+  highlights: string[];
+}

--- a/codegen/src/webui/components/types/tree-node.ts
+++ b/codegen/src/webui/components/types/tree-node.ts
@@ -1,0 +1,14 @@
+/**
+ * A node that can be rendered inside the generated tree navigation.
+ */
+export interface TreeNode {
+  id: string;
+  name: string;
+  type: 'aggregate' | 'registry' | 'component' | 'tool' | 'profile';
+  children?: TreeNode[];
+  metadata?: {
+    count?: number;
+    status?: string;
+    domain?: string;
+  };
+}


### PR DESCRIPTION
## Summary
- split API route and schema interfaces into individual files to honor the single-interface guideline
- extract generated WebUI component interfaces into dedicated type modules and import them where used

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae2398af883318fcc7001ef0bb84c)