### PR TITLE
Add useful context to folder README files

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,8 @@
-# .github
+# GitHub configuration
 
-This directory contains files for the `.github` component of the project.
+Automation, CI, and repository-level policy files live here.
+
+- **Workflows (`.github/workflows`)** run linting, tests, releases, and Docker publishing for the project. See the workflow README for a quick map of each job.
+- **Dependabot (`dependabot.yml`)** keeps npm and GitHub Action dependencies up to date on a weekly schedule.
+
+If you add new CI pipelines or repository automation, place them here so contributors can find everything GitHub-related in one place.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,3 +1,9 @@
-# .github/workflows
+# GitHub Actions workflows
 
-This directory contains files for the `.github/workflows` component of the project.
+Summary of the automation that runs in this repository:
+
+- **ci.yml** – installs dependencies and runs lint/test suites to validate pull requests.
+- **docker-publish.yml** – builds and pushes the application Docker image when releases are tagged.
+- **release-zip.yml** – packages build artifacts into a zip for distribution.
+
+When adding new workflows, keep them documented here so maintainers can see the full CI/CD surface at a glance.

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,3 +1,8 @@
-# .vscode
+# .vscode workspace settings
 
-This directory contains files for the `.vscode` component of the project.
+Workspace-level VS Code settings used across the monorepo:
+
+- **WSL Codex integration**: `chatgpt.runCodexInWindowsSubsystemForLinux` is enabled so the Codex runner uses the WSL environment. This keeps tooling consistent with the Linux-based project scripts.
+- Add any additional shared settings here (formatting overrides, default linters, or recommended extensions) so collaborators inherit the same editor behavior.
+
+> These settings are intentionally lightweight; repository-level formatter and lint rules still live in their respective packages.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,3 +1,8 @@
-# agents
+# Agent docs
 
-This directory contains files for the `agents` component of the project.
+Background material for the "agents" concept in this project lives here.
+
+- `agents-details/` – deeper documentation on architecture (plugin system, lifecycle builder), interfaces (CLI/Web UI), safety practices, and the developer persona that the platform targets. Start with `agents-details/README.md` for the full table of contents.
+- `old-system/` – legacy notes kept for historical reference.
+
+Use this folder to collect any new guidance for contributors building or extending the agent-based tooling.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,3 +1,21 @@
-# e2e
+# End-to-end tests
 
-This directory contains files for the `e2e` component of the project.
+Playwright-based regression tests for the app. This package uses Bun and `start-server-and-test` to boot the server and then run the browser suite.
+
+## Running locally
+
+```bash
+cd e2e
+bun install          # installs playwright and dependencies
+bun run test         # boots the app defined in ../config.json and runs the Playwright specs
+```
+
+`run-e2e.js` reads `config.json` at the repo root to decide which host/port to target, then proxies to `bun x playwright test` after the app is up.
+
+## Layout
+
+- `tests/` – individual Playwright specs (navigation, responsiveness, theming, language switching, etc.).
+- `playwright.config.ts` – shared Playwright settings.
+- `Dockerfile` – container image used in CI for reproducible test runs.
+
+Keep new specs under `tests/` and ensure they work headlessly so they can run in CI.

--- a/e2e/tests/README.md
+++ b/e2e/tests/README.md
@@ -1,3 +1,12 @@
-# e2e/tests
+# Playwright specs
 
-This directory contains files for the `e2e/tests` component of the project.
+Each file here targets a user flow:
+
+- `navigation-flow.spec.ts` – sanity check that the main pages and links render.
+- `responsive-design.spec.ts` – viewport snapshots to verify layouts at mobile/tablet/desktop sizes.
+- `theme-switching.spec.ts` and `language-switching.spec.ts` – verify UI toggles update content and styling.
+- `page-load.spec.ts` – ensures the home screen loads quickly without console errors.
+- `game-interactions.spec.ts` – validates interactive elements in the retro game experience.
+- `integration/` – any cross-feature scenarios that combine multiple behaviors.
+
+Add new specs with descriptive filenames so CI output immediately hints at the failing flow.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,7 @@
 # scripts
 
-This directory contains files for the `scripts` component of the project.
+Utility scripts that support development and maintenance tasks.
+
+- **clean.ts** – runs the clean plugin from the codegen package to delete common build artifacts (`dist`, `.next`, `coverage`, etc.). Supports `--targets`, `--dry-run`, and `--force` flags for safe cleanup. Use `bun run scripts/clean.ts --help` to see options.
+
+Add new repo-wide scripts here so they are easy to find and documented in one place.


### PR DESCRIPTION
## Summary
- expand folder-level README files with descriptions of their contents and key scripts
- document how to run the Playwright e2e suite and what each spec targets
- outline GitHub workflows and editor settings so contributors know where automation lives

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae2fb8a888331acaccaeae8187147)