### PR TITLE
Add Copilot conflict resolver workflow

### DIFF
--- a/.github/workflows/copilot-conflict-resolver.yml
+++ b/.github/workflows/copilot-conflict-resolver.yml
@@ -1,0 +1,86 @@
+name: Copilot conflict resolver
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write   # comment + label
+  issues: write          # PR comments are "issues" in the API
+  contents: read
+
+jobs:
+  request-copilot-conflict-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether PR has merge conflicts
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Only act on PRs originating from the same repo (avoid forks with pull_request_target).
+          head_repo="$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.head.repo.full_name')"
+          base_repo="$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.base.repo.full_name')"
+          if [ "$head_repo" != "$base_repo" ]; then
+            echo "same_repo=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "same_repo=true" >> "$GITHUB_OUTPUT"
+
+          # mergeable_state can be "unknown" briefly; retry.
+          state="unknown"
+          for i in 1 2 3 4 5 6; do
+            state="$(gh api repos/$REPO/pulls/$PR_NUMBER --jq '.mergeable_state // "unknown"')"
+            echo "Attempt $i: mergeable_state=$state"
+            if [ "$state" != "unknown" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          echo "mergeable_state=$state" >> "$GITHUB_OUTPUT"
+          if [ "$state" = "dirty" ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add label (optional)
+        if: steps.detect.outputs.same_repo == 'true' && steps.detect.outputs.has_conflicts == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            -f "labels[]=copilot/conflict-fix-requested" >/dev/null || true
+
+      - name: Ask Copilot to resolve conflicts and open a new PR
+        if: steps.detect.outputs.same_repo == 'true' && steps.detect.outputs.has_conflicts == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          body=$(cat <<'BODY'
+@copilot Please resolve the merge conflicts in this pull request.
+
+Requirements:
+- Merge the base branch into this PR branch and resolve conflicts correctly (do not drop changes).
+- Prefer minimal, correct resolutions; preserve intended behavior.
+- Run the repository’s tests/linters if available and fix any failures introduced by the merge resolution.
+- Open a new pull request with the conflict resolution on top of this PR, targeting the same base branch.
+BODY
+)
+
+          gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+            -f "body=$body" >/dev/null
+


### PR DESCRIPTION
## Summary
- add a pull_request_target workflow that detects merge conflicts on same-repo PRs
- automatically label conflicted PRs and request Copilot to open a resolved follow-up

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af7f16a6c8331959fec82b819730d)