### PR TITLE
Add lifecycle logger for lifecycle provider

### DIFF
--- a/retro-react-app/src/lib/lifecycle-provider.tsx
+++ b/retro-react-app/src/lib/lifecycle-provider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useEffect, useState } from "react";
 import { ComponentLifecycleStatus } from "./lifecycle-status";
+import { logLifecycleError } from "./logger";
 import type { IReactComponentLifecycle } from "./react-component-lifecycle";
 
 // Component lifecycle context
@@ -74,7 +75,8 @@ export function LifecycleProvider({
         }
 
         setGlobalStatus(ComponentLifecycleStatus.READY);
-      } catch {
+      } catch (error) {
+        logLifecycleError("Failed to initialize lifecycle components", error);
         setGlobalStatus(ComponentLifecycleStatus.ERROR);
       }
     };
@@ -89,11 +91,15 @@ export function LifecycleProvider({
     return (): void => {
       setGlobalStatus(ComponentLifecycleStatus.CLEANING);
 
-      const cleanupPromises = Array.from(components.values()).map(
-        async (component) => {
+      const cleanupPromises = Array.from(components.entries()).map(
+        async ([componentId, component]) => {
           try {
             await component.cleanup();
-          } catch {
+          } catch (error) {
+            logLifecycleError(
+              `Error cleaning up component with id ${componentId}`,
+              error,
+            );
             setGlobalStatus(ComponentLifecycleStatus.ERROR);
           }
         },
@@ -103,7 +109,8 @@ export function LifecycleProvider({
         .then(() => {
           setGlobalStatus(ComponentLifecycleStatus.DESTROYED);
         })
-        .catch(() => {
+        .catch((error) => {
+          logLifecycleError("Failed to clean up lifecycle components", error);
           setGlobalStatus(ComponentLifecycleStatus.ERROR);
         });
     };

--- a/retro-react-app/src/lib/logger.ts
+++ b/retro-react-app/src/lib/logger.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-console */
+
+export function logLifecycleError(message: string, error?: unknown): void {
+  if (error instanceof Error) {
+    console.error(`[Lifecycle] ${message}:`, error.message, error.stack);
+    return;
+  }
+
+  console.error(`[Lifecycle] ${message}:`, error);
+}


### PR DESCRIPTION
## Summary
- add a lifecycle-specific logger that wraps error reporting without using direct console calls in the provider
- use the logger during initialization and cleanup to capture lifecycle errors

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af8a4cdc08331a5b494c63d68302e)