### PR TITLE
Add explicit return type to request config

### DIFF
--- a/retro-react-app/src/i18n/request.ts
+++ b/retro-react-app/src/i18n/request.ts
@@ -1,5 +1,9 @@
 import { getRequestConfig } from "next-intl/server";
 
-export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`./messages/${locale}.json`)).default,
-}));
+type Messages = typeof import("./messages/en.json");
+
+export default getRequestConfig(
+  async ({ locale }): Promise<{ messages: Messages }> => ({
+    messages: (await import(`./messages/${locale}.json`)).default,
+  }),
+);


### PR DESCRIPTION
## Summary
- derive the messages type from the English locale JSON module
- annotate the async getRequestConfig callback with an explicit return type to satisfy linting rules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b228c55548331a42852b102c47b80)