### PR TITLE
Add repo-wide lint workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ chmod +x revolutionary-codegen.js
 ./revolutionary-codegen.js generate --spec-path my-project.json --enable-innovations --enable-typescript --enable-tests
 ```
 
+### Repo-wide linting
+
+Run both packages' lint suites together from the repository root:
+
+```bash
+bun run scripts/lint-all.ts
+```
+
 ## 📖 Project Specification
 
 The project is defined by a JSON specification file that includes:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,5 +3,6 @@
 Utility scripts that support development and maintenance tasks.
 
 - **clean.ts** – runs the clean plugin from the codegen package to delete common build artifacts (`dist`, `.next`, `coverage`, etc.). Supports `--targets`, `--dry-run`, and `--force` flags for safe cleanup. Use `bun run scripts/clean.ts --help` to see options.
+- **lint-all.ts** – runs linting for both packages in the repo (`npm run lint` in `codegen/` and `bunx eslint .` in `retro-react-app/`). Invoke with `bun run scripts/lint-all.ts` from the repository root.
 
 Add new repo-wide scripts here so they are easy to find and documented in one place.

--- a/scripts/lint-all.ts
+++ b/scripts/lint-all.ts
@@ -1,0 +1,31 @@
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const steps = [
+  {
+    name: 'codegen lint',
+    command: 'npm run lint',
+    cwd: resolve(repoRoot, 'codegen'),
+  },
+  {
+    name: 'retro-react-app lint',
+    command: 'bunx eslint .',
+    cwd: resolve(repoRoot, 'retro-react-app'),
+  },
+];
+
+function runStep(step: { name: string; command: string; cwd: string }) {
+  console.log(`\n▶️  Running ${step.name} (${step.command})`);
+  execSync(step.command, { stdio: 'inherit', cwd: step.cwd });
+}
+
+try {
+  steps.forEach(runStep);
+  console.log('\nAll lint steps completed successfully.');
+} catch (error) {
+  console.error('\nLint workflow failed.', error instanceof Error ? error.message : error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a repository-level lint-all script to run lint checks for both packages
- document the consolidated lint workflow in the scripts README and root README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b22b2a9848331845613b57988f558)