### PR TITLE
Automate task creation for CI test failures

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 Summary of the automation that runs in this repository:
 
-- **ci.yml** – installs dependencies and runs lint/test suites to validate pull requests.
+- **ci.yml** – installs dependencies, runs lint/test suites to validate pull requests, and opens a Codex or GitHub Pro task when tests fail.
 - **docker-publish.yml** – builds and pushes the application Docker image when releases are tagged.
 - **release-zip.yml** – packages build artifacts into a zip for distribution.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,79 @@ jobs:
       - name: Run Playwright smoke test
         run: bun run test
         working-directory: e2e
+
+  create-test-failure-task:
+    name: Create Codex or GitHub Pro task on test failure
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    if: always()
+    permissions:
+      issues: write
+      contents: read
+    env:
+      CODEX_WEBHOOK_URL: ${{ secrets.CODEX_WEBHOOK_URL }}
+    steps:
+      - name: Create Codex task for failing tests
+        if: ${{ needs.smoke-test.result == 'failure' && env.CODEX_WEBHOOK_URL != '' }}
+        run: |
+          cat >payload.json <<EOF
+          {
+            "type": "ci-test-failure",
+            "source": "github-actions",
+            "repository": "${{ github.repository }}",
+            "runId": "${{ github.run_id }}",
+            "runUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "commit": "${{ github.sha }}",
+            "branch": "${{ github.ref_name }}",
+            "message": "Playwright smoke test reported a failure."
+          }
+          EOF
+
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            --data @payload.json \
+            "$CODEX_WEBHOOK_URL"
+
+      - name: Open GitHub Pro task issue for failing tests
+        if: ${{ needs.smoke-test.result == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { repo, owner } = context.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `Fix CI test failure for run #${context.runNumber}`;
+            const labels = ['ci-failure', 'tests', 'github-pro-task'];
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: labels.join(','),
+            });
+
+            const duplicate = existing.find((issue) => issue.title === title);
+            if (duplicate) {
+              core.info(`Issue already exists: ${duplicate.html_url}`);
+              return;
+            }
+
+            const body = [
+              'Automated alert: tests failed in the Playwright smoke-test workflow.',
+              '',
+              `- Run: [#${context.runNumber}](${runUrl})`,
+              `- Commit: ${context.sha}`,
+              `- Branch: ${context.ref}`,
+              '',
+              'Please investigate the CI failure and resolve the failing tests.',
+            ].join('\n');
+
+            const { data: issue } = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels,
+            });
+
+            core.info(`Created GitHub Pro task issue: ${issue.html_url}`);


### PR DESCRIPTION
## Summary
- add a CI follow-up job that opens a Codex webhook or GitHub issue when the smoke tests fail
- document the new task automation in the workflows README

## Testing
- Not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3fcd6dd4833192328be672a31e34)