### PR TITLE
Add AI-assisted workflow guidance to GitHub config

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,8 @@
 
 Automation, CI, and repository-level policy files live here.
 
+- **AI-assisted workflows (`ai-assisted-workflows.md`)** outline how to drive label- and comment-based automation in GitHub without direct API calls.
 - **Workflows (`.github/workflows`)** run linting, tests, releases, and Docker publishing for the project. See the workflow README for a quick map of each job.
 - **Dependabot (`dependabot.yml`)** keeps npm and GitHub Action dependencies up to date on a weekly schedule.
 
-If you add new CI pipelines or repository automation, place them here so contributors can find everything GitHub-related in one place.
+If you add new CI pipelines or repository automation, place them here so contributors can find everything GitHub-related in one place. Keep the AI workflow guide updated when you add new labels or slash commands that automation depends on.

--- a/.github/ai-assisted-workflows.md
+++ b/.github/ai-assisted-workflows.md
@@ -1,0 +1,30 @@
+# AI-Assisted GitHub Workflows
+
+This repo prefers GitHub-native automation for AI assistance. Drive work with labels, plain-English comments, and task lists so everything stays auditable in issues and PR threads.
+
+## Core principles
+- **Stay inside GitHub**: Avoid direct API calls from the AI. Use labels, milestones, and template metadata.
+- **Plain-English communication**: Comment with intent, expected outcomes, and guardrails instead of opaque payloads.
+- **Labels as switches**: Reserve labels like `ai-ready`, `ai-in-progress`, `ai-needs-review`, `ai-blocked`, and `ai-follow-up` to drive automation and signal state.
+- **Native artifacts first**: Open issues, maintain task lists, and leave PR comments before reaching for external services.
+- **Auditability**: Keep decisions and status updates in the thread so humans can follow along and intervene.
+
+## Recommended flow
+1. **Open/prepare an issue** with the problem statement, acceptance criteria, and `ai-ready` label when it is actionable.
+2. **Draft a PR** from the AI and outline the plan in the description; keep status updates in comments rather than API callbacks.
+3. **Track tasks** with Markdown checklists that the AI checks off as work completes.
+4. **Hand off for review** by swapping to `ai-needs-review` and posting a recap of changes and verification notes.
+5. **Trigger validation** through labels or slash commands (e.g., `/run-tests`) that workflows can parse—never by custom endpoints.
+6. **Close out** by merging via the PR UI, closing linked issues, and posting a final changelog comment plus any `ai-follow-up` tags.
+
+## Comment and tag patterns
+- **Status**: “Completed lint setup; waiting on `/run-tests`.”
+- **Requests**: “@maintainers please review API retries; need confirmation on limits.”
+- **Actions**: Slash commands like `/run-tests` or `/create-issue <title>` that GitHub Actions consume—no direct API calls.
+- **Labels**: `ai-ready`, `ai-in-progress`, `ai-needs-review`, `ai-blocked`, `ai-follow-up` map to automation triggers.
+
+## Quick reliability checklist
+- Prefer labels/comments over external orchestration.
+- Mirror important summaries in PR descriptions.
+- Keep instructions human-readable, not tokenized.
+- Use deterministic workflows instead of ad-hoc scripts.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,3 +9,5 @@ Summary of the automation that runs in this repository:
 - **ai-code-review.yml** – asks both Copilot and Codex for a code review on every pull request event (including when the PR is closed).
 
 When adding new workflows, keep them documented here so maintainers can see the full CI/CD surface at a glance.
+
+AI-focused automation should follow the label- and comment-driven patterns in `../ai-assisted-workflows.md` (e.g., responding to `ai-ready`, `ai-needs-review`, or `/run-tests`). When you add new triggers, document the label or slash command in both the workflow file and that guide so the behavior stays discoverable.

--- a/agents/agents-details/systems/ai-assisted-github-workflows.md
+++ b/agents/agents-details/systems/ai-assisted-github-workflows.md
@@ -1,0 +1,31 @@
+# AI-Assisted GitHub Workflows
+
+A resilient way to coordinate AI help inside GitHub without depending on flaky API endpoints. Drive automation with labels/tags, comment-based cues, and native GitHub artifacts so the workflow keeps working even when external services are unavailable.
+
+## Core principles
+- **Stay in GitHub**: Avoid direct API calls from the AI. Express intent with labels, milestones, and templates that GitHub already understands.
+- **Plain-English communication**: Leave clear issue and PR comments instead of opaque payloads. Include the intent, the expected outcome, and any guardrails.
+- **Labels as switches**: Use consistent tags (e.g., `ai-ready`, `ai-needs-review`, `ai-failed-checks`) to trigger automations in Actions and to advertise state to teammates.
+- **Native artifacts first**: Open issues, create/check off task lists, and add PR comments before considering any external service.
+- **Auditability**: Keep decisions and actions in the thread so humans can follow the AI’s reasoning and intervene quickly.
+
+## Recommended flow
+1. **Start with an issue**: Describe the problem, expected deliverables, and acceptance criteria. Apply an `ai-ready` label when the description is complete.
+2. **Branch and PR**: Have the AI open a draft PR (or convert one) and summarize its plan in the description. Keep running commentary in updates instead of pushing status to an API.
+3. **Task tracking**: Maintain Markdown checklists inside the issue/PR to track steps. The AI checks boxes as it completes work.
+4. **Reviews and handoffs**: When ready for eyes-on, swap `ai-ready` for `ai-needs-review` and leave a plain-English recap comment covering what changed and what to verify.
+5. **Validation**: If automation is needed (tests, linting, deploys), trigger it with labels or slash-command comments (e.g., `/run-tests`) that Actions can listen to.
+6. **Merge and close**: After approval, merge via the PR UI and close linked issues. Post a final comment with a short changelog and any follow-up tags like `ai-follow-up`.
+
+## Comment and tagging patterns
+- **Status updates**: “Completed setup for linting. Waiting on `/run-tests` to finish.”
+- **Requests**: “@maintainers please review API error handling. Expecting confirmation on retry strategy.”
+- **Actions via comments**: Use predictable slash commands (`/run-tests`, `/create-issue <title>`) that GitHub Actions parse—no direct API calls from the AI.
+- **Labels that drive automation**: Map labels like `ai-ready`, `ai-in-progress`, `ai-needs-review`, `ai-blocked`, `ai-follow-up` to workflows so the AI never needs to hit APIs directly.
+
+## Reliability checklist for the AI
+- Never depend on custom endpoints for orchestration; prefer labels and comments.
+- Keep every decision and result in the PR/issue thread for traceability.
+- Prefer deterministic Actions workflows over ad-hoc scripts.
+- Mirror important summaries in the PR description so context survives rebases and force-pushes.
+- Keep instructions human-readable; avoid terse machine-coded tokens.

--- a/docs-viewer/public/docs/systems/ai-assisted-github-workflows.md
+++ b/docs-viewer/public/docs/systems/ai-assisted-github-workflows.md
@@ -1,0 +1,31 @@
+# AI-Assisted GitHub Workflows
+
+A resilient way to coordinate AI help inside GitHub without depending on flaky API endpoints. Drive automation with labels/tags, comment-based cues, and native GitHub artifacts so the workflow keeps working even when external services are unavailable.
+
+## Core principles
+- **Stay in GitHub**: Avoid direct API calls from the AI. Express intent with labels, milestones, and templates that GitHub already understands.
+- **Plain-English communication**: Leave clear issue and PR comments instead of opaque payloads. Include the intent, the expected outcome, and any guardrails.
+- **Labels as switches**: Use consistent tags (e.g., `ai-ready`, `ai-needs-review`, `ai-failed-checks`) to trigger automations in Actions and to advertise state to teammates.
+- **Native artifacts first**: Open issues, create/check off task lists, and add PR comments before considering any external service.
+- **Auditability**: Keep decisions and actions in the thread so humans can follow the AI’s reasoning and intervene quickly.
+
+## Recommended flow
+1. **Start with an issue**: Describe the problem, expected deliverables, and acceptance criteria. Apply an `ai-ready` label when the description is complete.
+2. **Branch and PR**: Have the AI open a draft PR (or convert one) and summarize its plan in the description. Keep running commentary in updates instead of pushing status to an API.
+3. **Task tracking**: Maintain Markdown checklists inside the issue/PR to track steps. The AI checks boxes as it completes work.
+4. **Reviews and handoffs**: When ready for eyes-on, swap `ai-ready` for `ai-needs-review` and leave a plain-English recap comment covering what changed and what to verify.
+5. **Validation**: If automation is needed (tests, linting, deploys), trigger it with labels or slash-command comments (e.g., `/run-tests`) that Actions can listen to.
+6. **Merge and close**: After approval, merge via the PR UI and close linked issues. Post a final comment with a short changelog and any follow-up tags like `ai-follow-up`.
+
+## Comment and tagging patterns
+- **Status updates**: “Completed setup for linting. Waiting on `/run-tests` to finish.”
+- **Requests**: “@maintainers please review API error handling. Expecting confirmation on retry strategy.”
+- **Actions via comments**: Use predictable slash commands (`/run-tests`, `/create-issue <title>`) that GitHub Actions parse—no direct API calls from the AI.
+- **Labels that drive automation**: Map labels like `ai-ready`, `ai-in-progress`, `ai-needs-review`, `ai-blocked`, `ai-follow-up` to workflows so the AI never needs to hit APIs directly.
+
+## Reliability checklist for the AI
+- Never depend on custom endpoints for orchestration; prefer labels and comments.
+- Keep every decision and result in the PR/issue thread for traceability.
+- Prefer deterministic Actions workflows over ad-hoc scripts.
+- Mirror important summaries in the PR description so context survives rebases and force-pushes.
+- Keep instructions human-readable; avoid terse machine-coded tokens.

--- a/docs-viewer/src/lib/docs-structure-data.ts
+++ b/docs-viewer/src/lib/docs-structure-data.ts
@@ -91,6 +91,12 @@ export const DOCS_STRUCTURE: DocSection[] = [
     path: "systems",
     files: [
       {
+        id: "ai-assisted-github-workflows",
+        title: "AI-Assisted GitHub Workflows",
+        path: "systems/ai-assisted-github-workflows.md",
+        section: "systems",
+      },
+      {
         id: "i18n-system",
         title: "i18n System",
         path: "systems/i18n-system.md",


### PR DESCRIPTION
## Summary
- add an AI-assisted GitHub workflow guide in the .github folder describing label- and comment-driven automation
- link the new guide from the .github README and workflow README so future automation follows the pattern

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b45cc16488331ad12a191e08ae82f)