### PR TITLE
Enable manual dispatch for CI workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 Summary of the automation that runs in this repository:
 
-- **ci.yml** – installs dependencies, runs lint/test suites to validate pull requests, and opens a Codex or GitHub Pro task when tests fail.
+- **ci.yml** – installs dependencies, runs lint/test suites to validate pull requests, and opens a Codex or GitHub Pro task when tests fail. Triggers on pushes to `main`, pull request events, or manual dispatches from the GitHub UI.
 - **ai-remediation.yml** – converts `ai-ready` issues into actionable AI tasks, tags PRs for AI review, and opens follow-up issues when AI reviewers request changes.
 - **bot_issue.yml** – automatically assigns Copilot to issues when they are labeled with `ci-failure`.
 - **docker-publish.yml** – builds and pushes the application Docker image when releases are tagged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
 
 jobs:
   ci-tasks:


### PR DESCRIPTION
## Summary
- allow the CI workflow to be manually dispatched from the GitHub UI
- document the CI workflow triggers alongside existing automation overview

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1719ad108331a1dba8896e70f92e)